### PR TITLE
Add configurable CSP to meta tags

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,9 +7,12 @@ import it from "date-fns/locale/it";
 import { TooltipProvider } from "./context/tooltip";
 import App from "./App";
 import { store } from "./store/store";
+import { renderCSP } from "./utils/meta";
 
 registerLocale("it", it);
 setDefaultLocale("it");
+
+renderCSP();
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/utils/meta.tsx
+++ b/src/utils/meta.tsx
@@ -1,0 +1,27 @@
+import { fromNullable } from "fp-ts/lib/Option";
+
+const getCSPContent = () => 
+`
+Content-Security-Policy-Report-Only: default-src 'self'; 
+script-src 'self'; 
+style-src 'self'; 
+object-src 'none'; 
+base-uri 'self';
+connect-src 'self' ${process.env.BASE_SPID_LOGIN_PATH} ${process.env.BASE_API_PATH} https://geocode.search.hereapi.com https://autocomplete.search.hereapi.com;
+font-src 'self'; 
+frame-src 'self'; 
+img-src 'self' https://cgnonboardingportalusa.blob.core.windows.net  https://www.spid.gov.it ${fromNullable(process.env.BASE_BLOB_PATH).getOrElse("")} ${process.env.NODE_ENV !== 'production' ? "https://upload.wikimedia.org/" : ""};
+manifest-src 'self'; 
+media-src 'self'; 
+worker-src 'none'; 
+frame-ancestors 'none';
+`;
+
+
+export const renderCSP = () => {
+    if (process.env.NODE_ENV === 'production'){
+        // eslint-disable-next-line functional/immutable-data
+        document.getElementsByTagName("head")[0].innerHTML += `<meta http-equiv="Content-Security-Policy" content="${getCSPContent()}">`;
+    }
+};
+    


### PR DESCRIPTION
This PR enable CSP content on meta tags, configurable by env variables.