### PR TITLE
[PE-275] Enables to order conventions by published discounts

### DIFF
--- a/src/components/OperatorConvention/OperatorConvention.tsx
+++ b/src/components/OperatorConvention/OperatorConvention.tsx
@@ -118,6 +118,8 @@ const OperatorConvention = () => {
         return "AgreementDate";
       case "agreementLastUpdateDate":
         return "LastModifyDate";
+      case "publishedDiscounts":
+        return "PublishedDiscounts";
     }
   };
 


### PR DESCRIPTION
This PR aims to enable the order by number of published discounts on backoffice table

This PR depends on pagopa/cgn-onboarding-portal-backend#121