### PR TITLE
feat: [PE-366] Add max limit to 2 for the product categories checkbox

### DIFF
--- a/src/components/Form/CreateDiscountForm/CreateDiscountForm.tsx
+++ b/src/components/Form/CreateDiscountForm/CreateDiscountForm.tsx
@@ -27,6 +27,7 @@ import StaticCode from "../CreateProfileForm/DiscountData/StaticCode";
 import FormField from "../FormField";
 import FormSection from "../FormSection";
 import { discountDataValidationSchema } from "../ValidationSchemas";
+import { MAX_CATEGORIES_SELECTED } from "../../../utils/constants";
 
 const emptyInitialValues = {
   name: "",
@@ -145,11 +146,13 @@ const CreateDiscountForm = () => {
               htmlFor="productCategories"
               isTitleHeading
               title="Categorie merceologiche"
-              description="Seleziona la o le categorie merceologiche a cui appatengono i beni/servizi oggetto dell’agevolazione"
+              description={`Seleziona al massimo ${MAX_CATEGORIES_SELECTED} categorie merceologiche a cui appatengono i beni/servizi oggetto dell’agevolazione`}
               isVisible
               required
             >
-              <ProductCategories />
+              <ProductCategories
+                selectedCategories={values.productCategories}
+              />
             </FormField>
             <FormField
               htmlFor="discountConditions"

--- a/src/components/Form/CreateProfileForm/DiscountData/DiscountData.tsx
+++ b/src/components/Form/CreateProfileForm/DiscountData/DiscountData.tsx
@@ -22,6 +22,7 @@ import {
   clearIfReferenceIsBlank,
   withNormalizedSpaces
 } from "../../../../utils/strings";
+import { MAX_CATEGORIES_SELECTED } from "../../../../utils/constants";
 import CenteredLoading from "../../../CenteredLoading/CenteredLoading";
 import DiscountConditions from "../../CreateProfileForm/DiscountData/DiscountConditions";
 import DiscountInfo from "../../CreateProfileForm/DiscountData/DiscountInfo";
@@ -170,13 +171,19 @@ const DiscountData = ({
               name: withNormalizedSpaces(discount.name),
               name_en: withNormalizedSpaces(discount.name_en),
               name_de: "-",
-              description: clearIfReferenceIsBlank(discount.description)(discount.description),
+              description: clearIfReferenceIsBlank(discount.description)(
+                discount.description
+              ),
               description_en: clearIfReferenceIsBlank(discount.description)(
                 discount.description_en
               ),
               description_de: "-",
-              condition: clearIfReferenceIsBlank(discount.condition)(discount.condition),
-              condition_en: clearIfReferenceIsBlank(discount.condition)(discount.condition_en),
+              condition: clearIfReferenceIsBlank(discount.condition)(
+                discount.condition
+              ),
+              condition_en: clearIfReferenceIsBlank(discount.condition)(
+                discount.condition_en
+              ),
               condition_de: "-",
               discountUrl: fromNullable(discount.discountUrl).toUndefined(),
               startDate: new Date(discount.startDate),
@@ -320,11 +327,14 @@ const DiscountData = ({
                         htmlFor="productCategories"
                         isTitleHeading
                         title="Categorie merceologiche"
-                        description="Seleziona la o le categorie merceologiche a cui appatengono i beni/servizi oggetto dell’agevolazione"
+                        description={`Seleziona al massimo ${MAX_CATEGORIES_SELECTED} categorie merceologiche a cui appatengono i beni/servizi oggetto dell’agevolazione`}
                         isVisible
                         required
                       >
-                        <ProductCategories index={index} />
+                        <ProductCategories
+                          selectedCategories={values.productCategories}
+                          index={index}
+                        />
                       </FormField>
                       <FormField
                         htmlFor="discountConditions"

--- a/src/components/Form/CreateProfileForm/DiscountData/ProductCategories.tsx
+++ b/src/components/Form/CreateProfileForm/DiscountData/ProductCategories.tsx
@@ -5,18 +5,25 @@ import { Label } from "reactstrap";
 import CustomErrorMessage from "../../CustomErrorMessage";
 import { categoriesMap } from "../../../../utils/strings";
 import { ProductCategory } from "../../../../api/generated";
+import { MAX_CATEGORIES_SELECTED } from "../../../../utils/constants";
 
 type Props = {
+  selectedCategories?: Array<ProductCategory>;
   index?: number;
 };
 
-const ProductCategories = ({ index }: Props) => {
+const ProductCategories = ({ selectedCategories, index }: Props) => {
   const hasIndex = index !== undefined;
   const name = hasIndex
     ? `discounts[${index}].productCategories`
     : `productCategories`;
 
   const nameLabelStyle = { fontWeight: 700, marginRight: "5px" };
+
+  const isCheckboxDisabled = (category: ProductCategory) =>
+    selectedCategories &&
+    selectedCategories.length >= MAX_CATEGORIES_SELECTED &&
+    !selectedCategories.includes(category);
 
   return (
     <>
@@ -25,6 +32,7 @@ const ProductCategories = ({ index }: Props) => {
           <Field
             id={`${name}.${categoryKey}`}
             name={name}
+            disabled={isCheckboxDisabled(categoryKey as ProductCategory)}
             value={categoryKey}
             type="checkbox"
           />

--- a/src/components/Form/CreateProfileForm/ProfileData/ProfileInfo.tsx
+++ b/src/components/Form/CreateProfileForm/ProfileData/ProfileInfo.tsx
@@ -35,7 +35,14 @@ const ProfileInfo = ({ formValues }: Props) => (
       <InputField
         htmlFor="profileName"
         title="Nome Operatore visualizzato"
-        description={<>Può essere una semplificazione del nome dell'Operatore più riconoscibile dall'utente (es. PagoPA vs PagoPA SPA) <br/>Il nome dell'operatore deve rispettare l'uso delle maiuscole previste del proprio brand name (es. PagoPA vs PAGOPA)</>}
+        description={
+          <>
+            Può essere una semplificazione del nome dell&apos;Operatore più
+            riconoscibile dall&apos;utente (es. PagoPA vs PagoPA SPA) <br />
+            Il nome dell&apos;operatore deve rispettare l&apos;uso delle
+            maiuscole previste del proprio brand name (es. PagoPA vs PAGOPA)
+          </>
+        }
         isVisible
         required
       >

--- a/src/components/Form/EditDiscountForm/EditDiscountForm.tsx
+++ b/src/components/Form/EditDiscountForm/EditDiscountForm.tsx
@@ -29,6 +29,7 @@ import StaticCode from "../CreateProfileForm/DiscountData/StaticCode";
 import FormField from "../FormField";
 import FormSection from "../FormSection";
 import { discountDataValidationSchema } from "../ValidationSchemas";
+import { MAX_CATEGORIES_SELECTED } from "../../../utils/constants";
 
 const emptyInitialValues = {
   name: "",
@@ -233,11 +234,13 @@ const EditDiscountForm = () => {
                 htmlFor="productCategories"
                 isTitleHeading
                 title="Categorie merceologiche"
-                description="Seleziona la o le categorie merceologiche a cui appatengono i beni/servizi oggetto dell’agevolazione"
+                description={`Seleziona al massimo ${MAX_CATEGORIES_SELECTED} categorie merceologiche a cui appatengono i beni/servizi oggetto dell’agevolazione`}
                 isVisible
                 required
               >
-                <ProductCategories />
+                <ProductCategories
+                  selectedCategories={values.productCategories}
+                />
               </FormField>
               <FormField
                 htmlFor="discountConditions"

--- a/src/components/Form/ValidationSchemas.ts
+++ b/src/components/Form/ValidationSchemas.ts
@@ -1,5 +1,6 @@
 import * as Yup from "yup";
 import { HelpRequestCategoryEnum } from "../../api/generated";
+import { MAX_CATEGORIES_SELECTED } from "../../utils/constants";
 
 const INCORRECT_EMAIL_ADDRESS = "L’indirizzo inserito non è corretto";
 const INCORRECT_CONFIRM_EMAIL_ADDRESS = "I due indirizzi devono combaciare";
@@ -9,6 +10,7 @@ const ONLY_STRING = "Solo lettere";
 const DISCOUNT_RANGE =
   "Lo sconto deve essere un numero intero compreso tra 1 e 100";
 const PRODUCT_CATEGORIES_ONE = "Selezionare almeno una categoria merceologica";
+const PRODUCT_CATEGORIES_MAX = `Selezionare al massimo ${MAX_CATEGORIES_SELECTED} categorie merceologiche`;
 const INCORRECT_WEBSITE_URL =
   "L’indirizzo inserito non è corretto, inserire la URL comprensiva di protocollo";
 
@@ -162,6 +164,7 @@ export const discountDataValidationSchema = (
         .notRequired(),
       productCategories: Yup.array()
         .min(1, PRODUCT_CATEGORIES_ONE)
+        .max(MAX_CATEGORIES_SELECTED, PRODUCT_CATEGORIES_MAX)
         .required(),
       condition: Yup.string().when(["condition_en"], {
         is: (_?: string) => _ && _.length > 0,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_CATEGORIES_SELECTED = 2;


### PR DESCRIPTION
## Short description
This PR introduces a max number of product categories to be selected into checkbox section

## List of changes proposed in this pull request
- Added a new custom function to detect if a checkbox must be disabled or not (a checkbox should be disabled only if there are at least 2 categories already selected)
- Added text that refers to the new max number of product categories to be selected

## How to test
- Login as operator
- Create or Edit a bonus (agevolazione)
- Scroll down when there are checkbox with all the product categories available
- Select 2 categories
