### PR TITLE
fix: [PE-437] label partiva iva operatore

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,21 @@ $ yarn start:uat
 ## Login in localhost 
 As soon as the dashboard is up and running, you will see a landing page where you should login. Choose what kind of login do you want (login as Operator or login as Admin).
 After that you logged in successfully, you will be redirected to UAT environemnt dashboard, so in this case you need to retrieve the token generated in UAT and put it in localhost env, to do so you have to:
-- Open the browser inspect console;
-- Type the following snippet: 
+- Open the browser inspect console and type the following snippet:
 ```js
-window.cookieStore.get("pagopa_token").then(el => console.log(`window.cookieStore.set(${JSON.stringify({...el, domain: "localhost"})})`));
+const dialog = window.document.createElement("dialog");
+dialog.innerText = "click here";
+dialog.onclick = async () => {
+  const token = await window.cookieStore.get("pagopa_token");
+  await navigator.clipboard.writeText(
+    `window.cookieStore.set(${JSON.stringify({
+      ...token,
+      domain: "localhost",
+    })}); window.location.reload();`
+  );
+  window.location.replace("http://localhost:3000");
+};
+window.document.body.appendChild(dialog);
+dialog.showModal();
 ```
-- Copy the logged snippet containing the token from console;
-- Back to http://localhost:3000
-- Open again the browser inspect console;
-- Paste the snippet copied before and press enter;
-- Reload the page and you are done ✅
+- Paste the snippet that was automatically placed in the clipboard in the browser console and press enter;

--- a/src/components/Form/ActivationForm.tsx
+++ b/src/components/Form/ActivationForm.tsx
@@ -50,8 +50,9 @@ const ActivationForm = (props: Props) => {
             </InputField>
             <InputField
               htmlFor="organizationFiscalCode"
-              title="Codice fiscale / Partita IVA"
+              title="Partita IVA"
               required
+              // NICE_TO_HAVE: aggiungere validazione della partita iva (può essere nazionale o estera, non può essere codice fiscale)
             >
               <Field
                 id="organizationFiscalCode"

--- a/src/components/Form/CreateProfileForm/ProfileData/ProfileInfo.tsx
+++ b/src/components/Form/CreateProfileForm/ProfileData/ProfileInfo.tsx
@@ -66,8 +66,9 @@ const ProfileInfo = ({ formValues }: Props) => (
     )}
     <InputField
       htmlFor="taxCodeOrVat"
-      title="Codice fiscale / Partita IVA"
+      title="Partita IVA"
       required
+      // NICE_TO_HAVE: aggiungere validazione della partita iva (può essere nazionale o estera, non può essere codice fiscale)
     >
       <Field id="taxCodeOrVat" name="taxCodeOrVat" type="text" disabled />
       <CustomErrorMessage name="taxCodeOrVat" />

--- a/src/components/OperatorActivations/OperatorActivationDetail.tsx
+++ b/src/components/OperatorActivations/OperatorActivationDetail.tsx
@@ -60,8 +60,9 @@ const OperatorActivationDetail = ({ operator, getActivations }: Props) => {
             value={operator.organizationName}
           />
           <ProfileItem
-            label="Codice fiscale / Partita IVA"
+            label="Partita IVA"
             value={operator.keyOrganizationFiscalCode}
+            // NICE_TO_HAVE: aggiungere validazione della partita iva (può essere nazionale o estera, non può essere codice fiscale)
           />
           <ProfileItem label="Indirizzo PEC" value={operator.pec} />
           {operator.insertedAt && (

--- a/src/components/OperatorConvention/Profile.tsx
+++ b/src/components/OperatorConvention/Profile.tsx
@@ -6,7 +6,7 @@ const Profile = ({ profile }: { profile: ApprovedAgreementProfile }) => (
     <div>
       <h5 className="mb-7 font-weight-bold">Dati relativi all’operatore</h5>
       <Item label="Ragione sociale operatore" value={profile.fullName} />
-      <Item label="Codice Fiscale / Partita IVA" value={profile.taxCodeOrVat} />
+      <Item label="Partita IVA" value={profile.taxCodeOrVat} />
       <Item label="Indirizzo PEC" value={profile.pecAddress} />
       <Item label="Sede legale" value={profile.legalOffice} />
       <Item label="Numero di telefono azienda" value={profile.telephoneNumber} />

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -46,7 +46,7 @@ const Profile = () => {
                   value={profile.fullName}
                 />
                 <ProfileItem
-                  label="Codice Fiscale / Partita IVA"
+                  label="Partita IVA"
                   value={profile.taxCodeOrVat}
                 />
                 <ProfileItem label="Indirizzo PEC" value={profile.pecAddress} />


### PR DESCRIPTION
## Short description
Change field label from codice fiscale and partita iva to partita iva only

## List of changes proposed in this pull request
- label change in admin -> access control
- label change in admin -> operator detail
- label change in user -> edit profile data
- label change insert operator form

## How to test
See screenshots here https://pagopa.atlassian.net/browse/PE-437?focusedCommentId=86594
