### PR TITLE
[PE-525] fix: discount url text overflow

### DIFF
--- a/src/components/OperatorConvention/Discount.tsx
+++ b/src/components/OperatorConvention/Discount.tsx
@@ -161,7 +161,7 @@ const Discount = ({
         <Item
           label="Link all’agevolazione"
           value={
-            <a href={discount.discountUrl} target="_blank" rel="noreferrer">
+            <a href={discount.discountUrl} target="_blank" rel="noreferrer" className="text-break">
               {discount.discountUrl}
             </a>
           }


### PR DESCRIPTION
## Short description
Fixed discount url text overllow

## List of changes proposed in this pull request
- Feature A
- Feature B

## How to test
- login as operator
- go to operator list
- open a discount with a long link

![before](https://github.com/pagopa/cgn-onboarding-portal-frontend/assets/1537394/2425d5f8-921f-4cba-91c4-3d2c1b58cc08)
![after](https://github.com/pagopa/cgn-onboarding-portal-frontend/assets/1537394/1507cebe-beb9-4488-bffc-e2db8ea885e4)


