### PR TITLE
PE-604 fix operator discounts list creation date column

### DIFF
--- a/src/components/Discounts/Discounts.tsx
+++ b/src/components/Discounts/Discounts.tsx
@@ -180,8 +180,10 @@ const Discounts = () => {
       {
         Header: "Aggiunta il",
         accessor: "startDate",
-        Cell: ({ row }: any) =>
-          format(new Date(row.values.startDate), "dd/MM/yyyy")
+        Cell: ({ row }) =>
+          row.original.creationDate
+            ? format(new Date(row.original.creationDate), "dd/MM/yyyy")
+            : null
       },
       {
         Header: "Stato",


### PR DESCRIPTION
## Short description
in the operator discounts list creation date column was populated with start date, now fixed
