### PR TITLE
fix: opeator discount list name column layout

### DIFF
--- a/src/components/Discounts/Discounts.tsx
+++ b/src/components/Discounts/Discounts.tsx
@@ -175,7 +175,22 @@ const Discounts = () => {
       {
         Header: "Nome agevolazione",
         accessor: "name",
-        sortType: "string"
+        sortType: "string",
+        Cell({ row }) {
+          return <div style={{
+            whiteSpace: "normal",
+            textOverflow: "ellipsis",
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+            width: "calc(190px - 1.5rem)",
+            height: "calc(56px - 0.5rem)",
+            overflow: "hidden",
+            wordBreak: "break-all",
+          }}>
+            {row.original.name}
+          </div>
+        }
       },
       {
         Header: "Aggiunta il",


### PR DESCRIPTION
## Short description
Fix layout overflow when discount name is too long.
This happens in opeator discount list screen.
