### PR TITLE
[PE-739] Handle operator limit 

### DIFF
--- a/src/components/Form/CreateActivationForm/CreateActivationForm.tsx
+++ b/src/components/Form/CreateActivationForm/CreateActivationForm.tsx
@@ -9,7 +9,7 @@ import {
   OrganizationWithReferents
 } from "../../../api/generated_backoffice";
 import ActivationForm from "../ActivationForm";
-import { simplifyAxios } from "../../../utils/simplifyAxios";
+import { normalizeAxiosResponse } from "../../../utils/normalizeAxiosResponse";
 
 const emptyInitialValues: OrganizationWithReferents = {
   keyOrganizationFiscalCode: "",
@@ -27,7 +27,7 @@ const CreateActivationForm = () => {
 
   const createActivation = async (organization: OrganizationWithReferents) => {
     setLoading(true);
-    const response = await simplifyAxios(
+    const response = await normalizeAxiosResponse(
       Api.AttributeAuthority.upsertOrganization(organization)
     );
     setLoading(false);

--- a/src/components/Form/EditActivationForm/EditActivationForm.tsx
+++ b/src/components/Form/EditActivationForm/EditActivationForm.tsx
@@ -9,7 +9,7 @@ import { ADMIN_PANEL_ACCESSI } from "../../../navigation/routes";
 import { OrganizationWithReferents } from "../../../api/generated_backoffice";
 import CenteredLoading from "../../CenteredLoading";
 import ActivationForm from "../ActivationForm";
-import { simplifyAxios } from "../../../utils/simplifyAxios";
+import { normalizeAxiosResponse } from "../../../utils/normalizeAxiosResponse";
 
 const emptyInitialValues: OrganizationWithReferents = {
   keyOrganizationFiscalCode: "",
@@ -40,7 +40,7 @@ const CreateActivationForm = () => {
 
   const createActivation = async (organization: OrganizationWithReferents) => {
     setSubmitting(true);
-    const response = await simplifyAxios(
+    const response = await normalizeAxiosResponse(
       Api.AttributeAuthority.upsertOrganization(organization)
     );
     setSubmitting(false);

--- a/src/utils/normalizeAxiosResponse.ts
+++ b/src/utils/normalizeAxiosResponse.ts
@@ -8,7 +8,7 @@ import { AxiosError, AxiosResponse } from "axios";
  */
 type StatusCodeOk = 200 | 201 | 204;
 type StatusCodeKo = 400 | 403 | 404 | 409 | 404 | 500;
-export async function simplifyAxios<Data>(
+export async function normalizeAxiosResponse<Data>(
   axiosOutcome: Promise<AxiosResponse<Data, unknown>>
 ): Promise<
   | { status: StatusCodeOk; data: Data }


### PR DESCRIPTION
## Short description
Any given non admin user can only operate for ten or less operators/merhcant/organization/entity (these words all stands for the same thing).
This limit is due other technical reasons (if needed I can describe it further)

## List of changes proposed in this pull request
- handle code 400 on upsetting an operator when CANNOT_BIND_MORE_THAN_TEN_ORGANIZATIONS

## How to test
Try to create or modify an operator as admin user, including in "referents" a user that already manages 10 or more other operators
