### PR TITLE
chore: Enabled maintenance banner

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -127,7 +127,7 @@ export default Login;
 const MAINTENANCE_BANNER:
   | undefined
   | "short-downtime"
-  | "long-downtime" = undefined;
+  | "long-downtime" = "short-downtime;
 
 function Alert({ title }: { title: string }) {
   return (


### PR DESCRIPTION
## Short description
This PR enables the maintenance banner to show on the login screen from March 18th from 9AM until the backend maintenance is completed