### PR TITLE
fix: [IOPB-1448] show bucket code for test modal

### DIFF
--- a/src/components/OperatorConvention/BucketCodeModal.tsx
+++ b/src/components/OperatorConvention/BucketCodeModal.tsx
@@ -17,21 +17,27 @@ const BucketCodeModal = ({
   agreementId,
   discountId
 }: Props) => {
-  const {
-    data: bucketCode = "",
-    isLoading
-  } = remoteData.Backoffice.Discount.getDiscountBucketCode.useQuery(
-    {
-      agreementId,
-      discountId
-    },
-    { enabled: isOpen }
-  );
+  const { data, isLoading, isError } =
+    remoteData.Backoffice.Discount.getDiscountBucketCode.useQuery(
+      {
+        agreementId,
+        discountId
+      },
+      { enabled: isOpen }
+    );
 
   return (
     <Modal isOpen={isOpen} toggle={toggle} size="md">
       <ModalHeader toggle={toggle}>Codice Sconto dalla lista</ModalHeader>
-      <ModalBody>{isLoading ? <CenteredLoading /> : bucketCode}</ModalBody>
+      <ModalBody>
+        {isLoading ? (
+          <CenteredLoading />
+        ) : data?.code && !isError ? (
+          data.code
+        ) : (
+          "Non è stato possibile caricare il codice"
+        )}
+      </ModalBody>
       <ModalFooter className="d-flex flex-column">
         <Button
           color="primary"


### PR DESCRIPTION
## Short description
There was a bug in bucket code visualization that broke the page.

## List of changes proposed in this pull request
- display string instead of object

## How to test
There must be merchant of bucket list type with a discount in test-pending status.
Login as ADMIN, navigate to this discount detail, click on "mostra codice" button, it should open a modal that displays a discount code.
If you click on "mostra codice" on a discount in a different state than test-pending then the modal should show a brief error message
