### PR TITLE
fix: [IOBP-1633] operator adsress fields empty error

### DIFF
--- a/src/components/Form/EditOperatorDataForm/EditOperatorDataForm.tsx
+++ b/src/components/Form/EditOperatorDataForm/EditOperatorDataForm.tsx
@@ -68,7 +68,7 @@ function getSalesChannel(salesChannel: any) {
       return {
         ...OfflineChannel,
         addresses:
-          EmptyAddresses.is(OfflineChannel.addresses) ||
+          EmptyAddresses.isValidSync(OfflineChannel.addresses) ||
           OfflineChannel.allNationalAddresses
             ? []
             : OfflineChannel.addresses.map((add: any) => ({
@@ -80,7 +80,7 @@ function getSalesChannel(salesChannel: any) {
       return {
         ...salesChannel,
         addresses:
-          EmptyAddresses.is(salesChannel.addresses) ||
+          EmptyAddresses.isValidSync(salesChannel.addresses) ||
           salesChannel.allNationalAddresses
             ? []
             : salesChannel.addresses.map((add: any) => ({

--- a/src/utils/form_types.tsx
+++ b/src/utils/form_types.tsx
@@ -1,17 +1,16 @@
 import * as Yup from "yup";
-import { YupLiteral } from "./yupUtils";
 
 export const EmptyAddresses = Yup.array(
   Yup.object({
-    street: YupLiteral("").required(),
-    zipCode: YupLiteral("").required(),
-    city: YupLiteral("").required(),
-    district: YupLiteral("").required(),
+    street: Yup.string().oneOf([""]),
+    zipCode: Yup.string().oneOf([""]),
+    city: Yup.string().oneOf([""]),
+    district: Yup.string().oneOf([""]),
     coordinates: Yup.object({
-      latitude: YupLiteral("").required(),
-      longitude: YupLiteral("").required()
-    }).required()
-  }).required()
-).required();
+      latitude: Yup.string().oneOf([""]),
+      longitude: Yup.string().oneOf([""])
+    })
+  })
+);
 
 export type EmptyAddresses = Yup.InferType<typeof EmptyAddresses>;


### PR DESCRIPTION
## Short description
Frontend was not sending to the backend the operator adresses field

## List of changes proposed in this pull request
- fix yup validation

## How to test
- in the onboarding wizard, go to tab with operator data, add some addresses and click continue.
- in the netowrk panel on PUT /profile there should be the addresses in the salesChannel field.
- reloading or going back to this tab the saved adresses should be still there
- remember to check/uncheck "Rappresenti un franchising" toggle to show the addresses form fields
