### PR TITLE
chore: [IOBP-1635] admin portal add error message for empty bucket list

### DIFF
--- a/src/components/OperatorConvention/BucketCodeModal.tsx
+++ b/src/components/OperatorConvention/BucketCodeModal.tsx
@@ -30,13 +30,6 @@ const BucketCodeModal = ({
     <Modal isOpen={isOpen} toggle={toggle} size="md">
       <ModalHeader toggle={toggle}>Codice Sconto dalla lista</ModalHeader>
       <ModalBody>
-        {isLoading ? (
-          <CenteredLoading />
-        ) : data?.code && !isError ? (
-          data.code
-        ) : (
-          "Non è stato possibile caricare il codice"
-        )}
         {(() => {
           if (isLoading) {
             return <CenteredLoading />;

--- a/src/components/OperatorConvention/BucketCodeModal.tsx
+++ b/src/components/OperatorConvention/BucketCodeModal.tsx
@@ -26,27 +26,26 @@ const BucketCodeModal = ({
       { enabled: isOpen, retry: false }
     );
 
+  const renderContent = () => {
+    if (isLoading) {
+      return <CenteredLoading />;
+    }
+    if (data?.code && !isError) {
+      return data.code;
+    }
+    if (
+      error?.status === 400 &&
+      error.response?.data ===
+        "CANNOT_RETRIEVE_BUCKET_CODE_FROM_DISCOUNT_WITH_EMPTY_BUCKET"
+    ) {
+      return "I codici sconto disponibili sono terminati. L’operatore deve caricare una nuova lista di codici per poter procedere.";
+    }
+    return "Non è stato possibile caricare il codice";
+  };
   return (
     <Modal isOpen={isOpen} toggle={toggle} size="md">
       <ModalHeader toggle={toggle}>Codice Sconto dalla lista</ModalHeader>
-      <ModalBody>
-        {(() => {
-          if (isLoading) {
-            return <CenteredLoading />;
-          }
-          if (data?.code && !isError) {
-            return data.code;
-          }
-          if (
-            error?.status === 400 &&
-            error.response?.data ===
-              "CANNOT_RETRIEVE_BUCKET_CODE_FROM_DISCOUNT_WITH_EMPTY_BUCKET"
-          ) {
-            return "I codici sconto disponibili sono terminati. L’operatore deve caricare una nuova lista di codici per poter procedere.";
-          }
-          return "Non è stato possibile caricare il codice";
-        })()}
-      </ModalBody>
+      <ModalBody>{renderContent()}</ModalBody>
       <ModalFooter className="d-flex flex-column">
         <Button
           color="primary"

--- a/src/components/OperatorConvention/BucketCodeModal.tsx
+++ b/src/components/OperatorConvention/BucketCodeModal.tsx
@@ -17,13 +17,13 @@ const BucketCodeModal = ({
   agreementId,
   discountId
 }: Props) => {
-  const { data, isLoading, isError } =
+  const { data, isLoading, isError, error } =
     remoteData.Backoffice.Discount.getDiscountBucketCode.useQuery(
       {
         agreementId,
         discountId
       },
-      { enabled: isOpen }
+      { enabled: isOpen, retry: false }
     );
 
   return (
@@ -37,6 +37,22 @@ const BucketCodeModal = ({
         ) : (
           "Non è stato possibile caricare il codice"
         )}
+        {(() => {
+          if (isLoading) {
+            return <CenteredLoading />;
+          }
+          if (data?.code && !isError) {
+            return data.code;
+          }
+          if (
+            error?.status === 400 &&
+            error.response?.data ===
+              "CANNOT_RETRIEVE_BUCKET_CODE_FROM_DISCOUNT_WITH_EMPTY_BUCKET"
+          ) {
+            return "I codici sconto disponibili sono terminati. L’operatore deve caricare una nuova lista di codici per poter procedere.";
+          }
+          return "Non è stato possibile caricare il codice";
+        })()}
       </ModalBody>
       <ModalFooter className="d-flex flex-column">
         <Button


### PR DESCRIPTION
## Short description
When an admin user requests a discount code for testing purposes, it can happen that there are no more discount codes available. This PR adds a specific message for that

## List of changes proposed in this pull request
- disabled retry for BE call, it is a GET but in fact it is a mutation since it consumes the code
- add specific message

## How to test
- Login into UAT as admin
- go to "operatori convenzionati" tab, then on the row "Forcuti - inserimento nuovo operatore 2"
- go to "in test" discount and click on "mostra codice" the new message should appear 
