### PR TITLE
fix: [IOBP-1665] Label content start date of opportunity

### DIFF
--- a/src/components/Discounts/DiscountDetailRow.tsx
+++ b/src/components/Discounts/DiscountDetailRow.tsx
@@ -306,7 +306,7 @@ Props) => {
               </td>
             </tr>
             <ProfileItem
-              label="Data di inizio dell'opportunità"
+              label="Data d'inizio opportunità"
               value={format(new Date(row.original.startDate), "dd/MM/yyyy")}
             />
             <ProfileItem

--- a/src/components/OperatorConvention/Discount.tsx
+++ b/src/components/OperatorConvention/Discount.tsx
@@ -115,7 +115,7 @@ const Discount = ({
       <Item label="Descrizione opportunità" value={discount.description} />
       <Item label="Stato" value={getBadgeStatus(discount.state)} />
       <Item
-        label="Data di inizio dell'opportunità"
+        label="Data d'inizio opportunità"
         value={format(new Date(discount.startDate), "dd/MM/yyyy")}
       />
       <Item


### PR DESCRIPTION
## Short description
This PR includes minor updates to the wording of labels in the `DiscountDetailRow` and `Discount` components to enhance consistency in the Italian localization.

## List of changes proposed in this pull request
  * Updated the label for the start date in `DiscountDetailRow` from `"Data di inizio dell'opportunità"` to `"Data d'inizio opportunità"` for consistency.
  * Updated the label for the start date in `Discount` from `"Data di inizio dell'opportunità"` to `"Data d'inizio opportunità"` for consistency.
