### PR TITLE
fix: [IOBP-1672,IOBP-1703,IOBP-1704,IOBP-1708] Adjust form error text, table column size and add missing alert

### DIFF
--- a/src/components/Form/FormSection.tsx
+++ b/src/components/Form/FormSection.tsx
@@ -18,7 +18,7 @@ type Props = {
 };
 
 const FormAlertInfoContent = () => (
-  <p className="mb-10 text-base font-weight-normal text-black">
+  <p className="alert alert-primary mb-10 text-base font-weight-normal text-black">
     Le domande contrassegnate con il simbolo * sono obbligatorie
     <br /> Le informazioni contrassegnate con il simbolo <VisibleIcon /> saranno
     visibili in app.

--- a/src/components/Form/ValidationSchemas.ts
+++ b/src/components/Form/ValidationSchemas.ts
@@ -60,7 +60,7 @@ export const ProfileDataValidationSchema = Yup.object().shape({
     .matches(/^[a-zA-Z\s]*$/, ONLY_STRING)
     .required(REQUIRED_FIELD),
   legalRepresentativeTaxCode: Yup.string()
-    .min(4, "Deve essere al minimo di 4 caratteri")
+    .min(4, "Inserisci un codice fiscale valido")
     .max(20, "Deve essere al massimo di 20 caratteri")
     .required(REQUIRED_FIELD),
   referent: ReferentValidationSchema,

--- a/src/components/Form/ValidationSchemas.ts
+++ b/src/components/Form/ValidationSchemas.ts
@@ -30,7 +30,7 @@ const ReferentValidationSchema = Yup.object().shape({
     .required(REQUIRED_FIELD),
   telephoneNumber: Yup.string()
     .matches(/^\d*$/, ONLY_NUMBER)
-    .min(4, "Deve essere di 4 caratteri")
+    .min(4, "Inserisci un numero di telefono valido")
     .required(REQUIRED_FIELD)
 });
 
@@ -54,7 +54,7 @@ export const ProfileDataValidationSchema = Yup.object().shape({
   legalOffice: Yup.string().required(REQUIRED_FIELD),
   telephoneNumber: Yup.string()
     .matches(/^\d*$/, ONLY_NUMBER)
-    .min(4, "Deve essere di 4 caratteri")
+    .min(4, "Inserisci un numero di telefono valido")
     .required(REQUIRED_FIELD),
   legalRepresentativeFullName: Yup.string()
     .matches(/^[a-zA-Z\s]*$/, ONLY_STRING)

--- a/src/components/Profile/ProfileItem.tsx
+++ b/src/components/Profile/ProfileItem.tsx
@@ -6,7 +6,12 @@ type Props = {
 
 const ProfileItem = ({ className = "", label, value }: Props) => (
   <tr>
-    <td className={`${className} px-0 text-gray border-bottom-0`}>{label}</td>
+    <td
+      className={`${className} px-0 text-gray border-bottom-0`}
+      style={{ width: "400px" }}
+    >
+      {label}
+    </td>
     <td
       className={`${className} border-bottom-0`}
       style={{


### PR DESCRIPTION
## Short description
This pull request include refining validation error messages, adding alert styling to form alerts, and adjusting the width of profile item labels for better readability

## List of changes proposed in this pull request
- Updated validation error messages for `telephoneNumber` and `legalRepresentativeTaxCode` fields to provide clearer guidance to users. For example, "Deve essere di 4 caratteri" was changed to "Inserisci un numero di telefono valido."
- Added `alert alert-primary` styling to the form alert content for better visibility and alignment with design conventions.
- Adjusted the width of the profile item label cells to 400px for improved layout consistency and readability.

## How to test
Ensure that all points are aligned with design requirements (Check out the jira task for more context)