### PR TITLE
fix: csp issue with zod

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import "./utils/zod-csp-fix";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter } from "react-router-dom";
 import { Provider } from "react-redux";

--- a/src/utils/zod-csp-fix.ts
+++ b/src/utils/zod-csp-fix.ts
@@ -1,0 +1,5 @@
+import { config } from "zod/v4";
+
+config({
+  jitless: true
+});


### PR DESCRIPTION
the website did not work in UAT because zod was using unsafe eval for compiling schemas, the eval is disabled now