### PR TITLE
chore: [IOBP-2019] Allow only https websites in forms

### DIFF
--- a/src/components/Form/CreateProfileForm/DiscountData/DiscountUrl.tsx
+++ b/src/components/Form/CreateProfileForm/DiscountData/DiscountUrl.tsx
@@ -16,7 +16,7 @@ function DiscountUrl({ formLens }: Props) {
         id="discountUrl"
         formLens={formLens.focus("discountUrl")}
         type="text"
-        placeholder="Inserisci link (completo di protocollo http o https)"
+        placeholder="Inserisci link (completo di protocollo https)"
         className="form-control"
       />
       <FormErrorMessage formLens={formLens.focus("discountUrl")} />

--- a/src/components/Form/CreateProfileForm/DiscountData/EnrollToEyca.tsx
+++ b/src/components/Form/CreateProfileForm/DiscountData/EnrollToEyca.tsx
@@ -207,7 +207,7 @@ const EnrollToEyca = ({ profile, index, formLens }: Props) => {
         <Field
           id="eycaLandingPageUrl"
           formLens={formLens.focus("eycaLandingPageUrl")}
-          placeholder="Inserisci indirizzo (completo di protocollo http o https)"
+          placeholder="Inserisci indirizzo (completo di protocollo https)"
           className="form-control"
           type="text"
         />

--- a/src/components/Form/CreateProfileForm/DiscountData/LandingPage.tsx
+++ b/src/components/Form/CreateProfileForm/DiscountData/LandingPage.tsx
@@ -16,7 +16,7 @@ function LandingPage({ formLens, children }: Props) {
       <Field
         id="landing"
         formLens={formLens.focus("landingPageUrl")}
-        placeholder="Inserisci indirizzo (completo di protocollo http o https)"
+        placeholder="Inserisci indirizzo (completo di protocollo https)"
         type="text"
         className="form-control"
       />

--- a/src/components/Form/ValidationSchemas.ts
+++ b/src/components/Form/ValidationSchemas.ts
@@ -114,7 +114,7 @@ export const SalesChannelValidationSchema = z
       .union([
         z.url({
           error: INCORRECT_WEBSITE_URL,
-          protocol: /^https?$/,
+          protocol: /^https$/,
           hostname: z.regexes.domain
         }),
         z
@@ -302,7 +302,7 @@ export const discountDataValidationSchema = (
         z.string().trim().max(0, INCORRECT_WEBSITE_URL),
         z.url({
           error: INCORRECT_WEBSITE_URL,
-          protocol: /^https?$/,
+          protocol: /^https$/,
           hostname: z.regexes.domain
         })
       ]),
@@ -355,7 +355,7 @@ export const discountDataValidationSchema = (
         z.string().trim().max(0, INCORRECT_WEBSITE_URL),
         z.url({
           error: INCORRECT_WEBSITE_URL,
-          protocol: /^https?$/,
+          protocol: /^https$/,
           hostname: z.regexes.domain
         })
       ]),
@@ -368,7 +368,7 @@ export const discountDataValidationSchema = (
         z.string().trim().max(0, INCORRECT_WEBSITE_URL),
         z.url({
           error: INCORRECT_WEBSITE_URL,
-          protocol: /^https?$/,
+          protocol: /^https$/,
           hostname: z.regexes.domain
         })
       ])


### PR DESCRIPTION
## Short description
We restrict ulrs provided by the operator for mechants to https protocol. Backend team already mirated all values inn the database.

## List of changes proposed in this pull request
- change labels
- change form validations

## How to test
- as non admin user you should be apbel to input only https protocols urls in the following forms
- when editing merchant information, if the sales channel type is online type, the website url for the merchant
  - (this form show up in the second step of the onbiarding wizard, or by clicking on modify data once the non admin user logs in an sìhad selected a merchant to operate for)
- when editing discount information
  - discount url (you can put this always in)
  - eyca landding page (mandatory when tick checkobx for enabling eyca)
  - landing page (mandatory for the discount if merchant sales channel is "landing page")
  - this form shows up in the thirs step of the onboarding wizard, also once loggeded in as operator and creating or editing any discount

