### PR TITLE
fix: [IOBP-2538] always show partner website field in operator details

### DIFF
--- a/src/components/Form/CreateProfileForm/ProfileData/SalesChannels.tsx
+++ b/src/components/Form/CreateProfileForm/ProfileData/SalesChannels.tsx
@@ -26,16 +26,12 @@ const SalesChannels = ({ formLens, entityType, children }: Props) => {
   );
   const addresses = useWatch(formLens.focus("addresses").interop());
   const addressesArray = useFieldArray(formLens.focus("addresses").interop());
-  const hasOnlineOrBothChannels =
-    channelType === "OnlineChannel" || channelType === "BothChannels";
-  const hasWebsite =
-    hasOnlineOrBothChannels || entityType === EntityType.PublicAdministration;
   return (
     <>
       <SalesChannelDiscountCodeType formLens={formLens} />
       {formLens
         .focus("addresses")
-        .map(addressesArray.fields, (_, itemLens, index, array) => (
+        .map(addressesArray.fields, (_, itemLens, index) => (
           <FormSection
             key={index}
             title={index + 1 >= 2 ? `Indirizzo ${index + 1}` : `Indirizzo`}
@@ -172,38 +168,34 @@ const SalesChannels = ({ formLens, entityType, children }: Props) => {
                       </span>
                     </div>
                   )}
-                  {!hasWebsite && index === array.length - 1 ? children : null}
                 </>
               )}
             </div>
           </FormSection>
         ))}
-      {hasWebsite && (
-        <FormSection
-          title="Sito web"
-          description={(() => {
-            switch (entityType) {
-              case EntityType.Private:
-                return "Inserire l'URL del proprio e-commerce o del proprio sito istituzionale";
-              case EntityType.PublicAdministration:
-              default:
-                return "Inserisci l’URL del tuo e-commerce o sito per permettere alle persone di conoscere la tua attività";
-            }
-          })()}
-          required
-          isVisible
-        >
-          <Field
-            id="websiteUrl"
-            formLens={formLens.focus("websiteUrl")}
-            type="text"
-            placeholder="Inserisci un sito web (completo di protocollo https)"
-            className="form-control"
-          />
-          <FormErrorMessage formLens={formLens.focus("websiteUrl")} />
-          {children}
-        </FormSection>
-      )}
+      <FormSection
+        title="Sito web"
+        description={(() => {
+          switch (entityType) {
+            case EntityType.Private:
+              return "Inserire l'URL del proprio e-commerce o del proprio sito istituzionale";
+            case EntityType.PublicAdministration:
+            default:
+              return "Inserisci l’URL del tuo e-commerce o sito per permettere alle persone di conoscere la tua attività";
+          }
+        })()}
+        isVisible
+      >
+        <Field
+          id="websiteUrl"
+          formLens={formLens.focus("websiteUrl")}
+          type="text"
+          placeholder="Inserisci un sito web (completo di protocollo https)"
+          className="form-control"
+        />
+        <FormErrorMessage formLens={formLens.focus("websiteUrl")} />
+        {children}
+      </FormSection>
     </>
   );
 };

--- a/src/components/Form/ValidationSchemas.ts
+++ b/src/components/Form/ValidationSchemas.ts
@@ -135,15 +135,6 @@ export const SalesChannelValidationSchema = z
       ctx.value.channelType === SalesChannelType.OnlineChannel ||
       ctx.value.channelType === SalesChannelType.BothChannels
     ) {
-      if (!ctx.value.websiteUrl) {
-        // eslint-disable-next-line functional/immutable-data
-        ctx.issues.push({
-          input: ctx.value.websiteUrl,
-          path: ["websiteUrl"],
-          code: "custom",
-          message: REQUIRED_FIELD
-        });
-      }
       if (!ctx.value.discountCodeType) {
         // eslint-disable-next-line functional/immutable-data
         ctx.issues.push({


### PR DESCRIPTION
## Short description
This PR ensures that the partner website field is always visible in the operator details,
regardless of the recognition mode, and is managed independently from the landing page

## List of changes proposed in this pull request
- Ensured the partner website field is always displayed in the operator description
- Updated field configuration so the partner website is no longer required

## How to test
Verify that the partner website field is always visible in the operator details page, that it can be left empty without preventing form submission, and that editing the field works correctly without affecting the landing page URL
