### PR TITLE
fix: [IOBP-2556] website field required if BothChannel or OnlineChannel, optional if OfflineChannel

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -9,6 +9,7 @@
     "src/api/generated_backoffice/**",
     "src/api/generated_public/**",
     "src/types/**",
-    "extensions/**"
+    "extensions/**",
+    ".yarn/**"
   ]
 }

--- a/src/components/Form/CreateProfileForm/ProfileData/SalesChannels.tsx
+++ b/src/components/Form/CreateProfileForm/ProfileData/SalesChannels.tsx
@@ -26,6 +26,8 @@ const SalesChannels = ({ formLens, entityType, children }: Props) => {
   );
   const addresses = useWatch(formLens.focus("addresses").interop());
   const addressesArray = useFieldArray(formLens.focus("addresses").interop());
+  const hasOnlineOrBothChannels =
+    channelType === "OnlineChannel" || channelType === "BothChannels";
   return (
     <>
       <SalesChannelDiscountCodeType formLens={formLens} />
@@ -184,6 +186,7 @@ const SalesChannels = ({ formLens, entityType, children }: Props) => {
               return "Inserisci l’URL del tuo e-commerce o sito per permettere alle persone di conoscere la tua attività";
           }
         })()}
+        required={hasOnlineOrBothChannels}
         isVisible
       >
         <Field

--- a/src/components/Form/ValidationSchemas.ts
+++ b/src/components/Form/ValidationSchemas.ts
@@ -135,6 +135,15 @@ export const SalesChannelValidationSchema = z
       ctx.value.channelType === SalesChannelType.OnlineChannel ||
       ctx.value.channelType === SalesChannelType.BothChannels
     ) {
+      if (!ctx.value.websiteUrl) {
+        // eslint-disable-next-line functional/immutable-data
+        ctx.issues.push({
+          input: ctx.value.websiteUrl,
+          path: ["websiteUrl"],
+          code: "custom",
+          message: REQUIRED_FIELD
+        });
+      }
       if (!ctx.value.discountCodeType) {
         // eslint-disable-next-line functional/immutable-data
         ctx.issues.push({


### PR DESCRIPTION
## Short description
This PR ensures that the partner website field is always displayed in the operator details and its requirement is correctly managed depending on the channel type

## List of changes proposed in this pull request
- Ensured the website field is always shown in the operator description
- Ensured the website field is required for OnlineChannel and BothChannel
- Ensured the website field is optional for OfflineChannel

## How to test
Verify that the website field is always visible in the operator details page, that it is required only when expected based on the channel type (Online and Both channel)