### PR TITLE
fix: [IEG-2761] reorder export filenames to ISO date format

### DIFF
--- a/src/components/OperatorConvention/ConventionFilter.tsx
+++ b/src/components/OperatorConvention/ConventionFilter.tsx
@@ -43,7 +43,7 @@ const ConventionFilter = ({
         blob,
         `${today.getFullYear()}-${
           today.getMonth() + 1
-        }-${today.getDate()}/Esercenti CGN`
+        }-${today.getDate()}_Esercenti CGN`
       );
     } catch {
       triggerTooltip({
@@ -74,7 +74,7 @@ const ConventionFilter = ({
         blob,
         `${today.getFullYear()}-${
           today.getMonth() + 1
-        }-${today.getDate()}/Opportunità Eyca`
+        }-${today.getDate()}_Opportunità Eyca`
       );
     } catch {
       triggerTooltip({

--- a/src/components/OperatorConvention/ConventionFilter.tsx
+++ b/src/components/OperatorConvention/ConventionFilter.tsx
@@ -41,9 +41,9 @@ const ConventionFilter = ({
       const today = new Date();
       saveAs(
         blob,
-        `Esercenti CGN - ${today.getDate()}/${
+        `${today.getFullYear()}-${
           today.getMonth() + 1
-        }/${today.getFullYear()}`
+        }-${today.getDate()}/Esercenti CGN`
       );
     } catch {
       triggerTooltip({
@@ -72,9 +72,9 @@ const ConventionFilter = ({
       const today = new Date();
       saveAs(
         blob,
-        `Opportunità Eyca - ${today.getDate()}/${
+        `${today.getFullYear()}-${
           today.getMonth() + 1
-        }/${today.getFullYear()}`
+        }-${today.getDate()}/Opportunità Eyca`
       );
     } catch {
       triggerTooltip({


### PR DESCRIPTION
## Short description
This PR fixes the export filename format to use ISO date order (YYYY/MM/DD) and moves the name after the date. 

## List of changes proposed in this pull request
- Reordered export filenames to use ISO date format (YYYY/MM/DD_Name) for both "Esercenti CGN" and "Opportunità Eyca" 

## How to test
Log in as admin, go to the operators list, export both "Esercenti CGN" and "Opportunità Eyca" files and verify the downloaded filenames follow the format YYYY/MM/DD_Name.