### PR TITLE
fix [IEG-2778]: update copy in ProfileDescription and ProfileImage sections 

### DIFF
--- a/src/components/Form/CreateProfileForm/ProfileData/ProfileDescription.tsx
+++ b/src/components/Form/CreateProfileForm/ProfileData/ProfileDescription.tsx
@@ -11,12 +11,15 @@ const ProfileDescription = ({
 }: {
   formLens: Lens<ProfileFormValues>;
 }) => (
-  <FormSection
-    title="Descrizione dell'operatore"
-    description="Inserisci una descrizione dei beni o servizi offerti agli utenti tramite app IO. La descrizione è obbligatoria sia in italiano che in inglese - Max 300 caratteri"
-    required
-    isVisible
-  >
+  <FormSection title="Descrizione dell'operatore" required isVisible>
+    <p className="text-sm fw-normal text-black">
+      Descrivi in modo chiaro e semplice i servizi offerti agli utenti di Carta
+      Giovani (obbligatoria in italiano e in inglese – max 300 caratteri).
+      <br />
+      Usa parole chiave pertinenti: questo testo viene indicizzato nella
+      funzione “Ricerca” dell’app IO e influisce direttamente sulla visibilità
+      della tua offerta e sull’esperienza degli utenti.
+    </p>
     <div className="row">
       <div className="col-6">
         <p className="text-sm fw-normal text-black mb-0">Italiano 🇮🇹</p>

--- a/src/components/Form/CreateProfileForm/ProfileData/ProfileDescription.tsx
+++ b/src/components/Form/CreateProfileForm/ProfileData/ProfileDescription.tsx
@@ -11,15 +11,22 @@ const ProfileDescription = ({
 }: {
   formLens: Lens<ProfileFormValues>;
 }) => (
-  <FormSection title="Descrizione dell'operatore" required isVisible>
-    <p className="text-sm fw-normal text-black">
-      Descrivi in modo chiaro e semplice i servizi offerti agli utenti di Carta
-      Giovani (obbligatoria in italiano e in inglese – max 300 caratteri).
-      <br />
-      Usa parole chiave pertinenti: questo testo viene indicizzato nella
-      funzione “Ricerca” dell’app IO e influisce direttamente sulla visibilità
-      della tua offerta e sull’esperienza degli utenti.
-    </p>
+  <FormSection
+    title="Descrizione dell'operatore"
+    required
+    isVisible
+    description={
+      <>
+        Descrivi in modo chiaro e semplice i servizi offerti agli utenti di
+        Carta Giovani (obbligatoria in italiano e in inglese - max 300
+        caratteri).
+        <br />
+        Usa parole chiave pertinenti: questo testo viene indicizzato nella
+        funzione “Ricerca” dell’app IO e influisce direttamente sulla visibilità
+        della tua offerta e sull’esperienza degli utenti.
+      </>
+    }
+  >
     <div className="row">
       <div className="col-6">
         <p className="text-sm fw-normal text-black mb-0">Italiano 🇮🇹</p>

--- a/src/components/Form/CreateProfileForm/ProfileData/ProfileImage.tsx
+++ b/src/components/Form/CreateProfileForm/ProfileData/ProfileImage.tsx
@@ -95,7 +95,7 @@ const ProfileImage = () => {
   return (
     <FormSection
       title="Immagine operatore"
-      description="Carica un'immagine che rappresenti i beni o i servizi trattati dall'operatore"
+      description="Carica il tuo logo ufficiale o un’immagine che possa aiutare a identificare la tua offerta"
       footerDescription={FooterDescription}
       isVisible
       required


### PR DESCRIPTION
## Short description
Update copy in ProfileDescription and ProfileImage form sections. 

## List of changes proposed in this pull request
- Updated copy in ProfileDescription section   
- Updated copy in ProfileImage section

## How to test
Open the operator profile creation form and verify the updated copy in the "Descrizione dell'operatore" and "Immagine operatore" sections. 

### Before
<img width="1467" height="802" alt="image" src="https://github.com/user-attachments/assets/f465716d-c19d-476b-b556-35db3ea3c5bb" />

### Updated
<img width="1467" height="802" alt="image" src="https://github.com/user-attachments/assets/e25bdf2a-acc9-4bad-963e-70795d331ed1" />

