### PR TITLE
chore(deps): [IEG-2897] Update `react-router-dom` to `v7`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -108,7 +108,18 @@ export default tseslint.config(
           }
         }
       ],
-      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-floating-promises": [
+        "error",
+        {
+          allowForKnownSafeCalls: [
+            {
+              from: "package",
+              name: "NavigateFunction",
+              package: "react-router"
+            }
+          ]
+        }
+      ],
       "no-unused-expressions": "off",
       "@typescript-eslint/no-unused-expressions": ["error"],
       "@typescript-eslint/prefer-function-type": "error",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.60.0",
     "react-redux": "^9.2.0",
-    "react-router-dom": "^5.2.0",
+    "react-router-dom": "^7.2.0",
     "reactstrap": "^9.2.3",
     "zod": "^3.25.72"
   },
@@ -61,7 +61,6 @@
     "@types/node": "^24.0.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.0.4",
-    "@types/react-router-dom": "^5.1.7",
     "@types/react-table": "^7.0.29",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "3.2.4",

--- a/src/authentication/AuthenticationProvider.tsx
+++ b/src/authentication/AuthenticationProvider.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useState, useEffect, useCallback, useMemo } from "react";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { DASHBOARD, ADMIN_PANEL_RICHIESTE, LOGIN } from "../navigation/routes";
 import { useLoginRedirect, adminLogoutRedirect } from "./authentication";
 import {
@@ -16,8 +16,7 @@ export function AuthenticationProvider({
   children: React.ReactNode;
 }) {
   useLoginRedirect();
-  const history = useHistory();
-  const historyPush = history.push;
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [persistedState, setPersistedState] = useState(authenticationStore.get);
   useEffect(
@@ -37,26 +36,26 @@ export function AuthenticationProvider({
     (session: CurrentSession) => {
       authenticationStore.setCurrentSession(session);
       if (session?.type === "user") {
-        historyPush(DASHBOARD);
+        navigate(DASHBOARD);
       }
       if (session?.type === "admin") {
-        historyPush(ADMIN_PANEL_RICHIESTE);
+        navigate(ADMIN_PANEL_RICHIESTE);
       }
       resetQueries();
     },
-    [historyPush, resetQueries]
+    [navigate, resetQueries]
   );
   const logout = useCallback(
     (session: CurrentSession) => {
       authenticationStore.deleteSession(session);
       authenticationStore.setCurrentSession({ type: "none" });
-      historyPush(LOGIN);
+      navigate(LOGIN);
       resetQueries();
       if (session?.type === "admin") {
         adminLogoutRedirect();
       }
     },
-    [historyPush, resetQueries]
+    [navigate, resetQueries]
   );
   const value = useMemo<AuthenticationContextType>(
     () => ({

--- a/src/authentication/authentication.ts
+++ b/src/authentication/authentication.ts
@@ -2,7 +2,7 @@ import { PublicClientApplication } from "@azure/msal-browser";
 import { useQueryClient } from "@tanstack/react-query";
 import { jwtDecode } from "jwt-decode";
 import { useEffect } from "react";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { z } from "zod/v4";
 import { API_INDEX_BASE_URL, API_PUBLIC_BASE_URL } from "../api/common";
 import { OrganizationsDataApi } from "../api/generated";
@@ -174,8 +174,7 @@ const userLoginRedirectPromise = onUserLoginRedirect();
 const adminLoginRedirectPromise = onAdminLoginRedirect();
 
 export function useLoginRedirect() {
-  const history = useHistory();
-  const historyPush = history.push;
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
 
   useEffect(() => {
@@ -192,9 +191,9 @@ export function useLoginRedirect() {
           merchantFiscalCode: undefined
         });
         resetQueries();
-        historyPush(DASHBOARD);
+        navigate(DASHBOARD);
       } else if (state.type === "error") {
-        historyPush(LOGIN);
+        navigate(LOGIN);
       }
     });
 
@@ -205,8 +204,8 @@ export function useLoginRedirect() {
           name: state.name
         });
         resetQueries();
-        historyPush(ADMIN_PANEL_RICHIESTE);
+        navigate(ADMIN_PANEL_RICHIESTE);
       }
     });
-  }, [historyPush, queryClient]);
+  }, [navigate, queryClient]);
 }

--- a/src/components/Discounts/DiscountDetailRow.tsx
+++ b/src/components/Discounts/DiscountDetailRow.tsx
@@ -1,7 +1,7 @@
 import { format } from "date-fns";
 import { Button, Icon } from "design-react-kit";
 import { Fragment, useMemo, useState } from "react";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Row } from "@tanstack/react-table";
 import {
   Agreement,
@@ -54,7 +54,7 @@ const DiscountDetailRow = ({
   isPendingDelete,
   maxPublishedDiscountsReached
 }: Props) => {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [canBePublished, setCanBePublished] = useState(
     row.original.lastBucketCodeLoadStatus
       ? row.original.lastBucketCodeLoadStatus === BucketCodeLoadStatus.Finished
@@ -87,7 +87,7 @@ const DiscountDetailRow = ({
         color={"primary"}
         outline
         tag="button"
-        onClick={() => history.push(getEditDiscountRoute(row.original.id))}
+        onClick={() => navigate(getEditDiscountRoute(row.original.id))}
       >
         {row.original.state !== "expired" ? (
           <EditIcon fill={"#0273E6"} />
@@ -167,7 +167,7 @@ const DiscountDetailRow = ({
                 <button
                   className="btn btn-link fw-bold p-0 my-2"
                   onClick={() => {
-                    history.push(getEditDiscountRoute(row.original.id));
+                    navigate(getEditDiscountRoute(row.original.id));
                   }}
                 >
                   Modifica opportunità

--- a/src/components/Form/CreateEditActivationForm.tsx
+++ b/src/components/Form/CreateEditActivationForm.tsx
@@ -1,4 +1,4 @@
-import { useHistory, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import z from "zod/v4";
 import { useMemo } from "react";
 import { Icon } from "design-react-kit";
@@ -47,13 +47,13 @@ function dataToFormValues(
 
 const CreateEditActivationForm = () => {
   const { operatorFiscalCode } = useParams<{ operatorFiscalCode: string }>();
-  const history = useHistory();
+  const navigate = useNavigate();
   const { triggerTooltip } = useTooltip();
 
   const upsertActivationMutation =
     remoteData.Backoffice.AttributeAuthority.upsertOrganization.useMutation({
       onSuccess() {
-        history.push(ADMIN_PANEL_ACCESSI);
+        navigate(ADMIN_PANEL_ACCESSI);
       },
       async onError(error) {
         if (
@@ -77,7 +77,7 @@ const CreateEditActivationForm = () => {
   const organizationQuery =
     remoteData.Backoffice.AttributeAuthority.getOrganization.useQuery(
       {
-        keyOrganizationFiscalCode: operatorFiscalCode
+        keyOrganizationFiscalCode: operatorFiscalCode!
       },
       {
         enabled: Boolean(operatorFiscalCode)
@@ -115,7 +115,7 @@ const CreateEditActivationForm = () => {
           body: {
             ...values,
             keyOrganizationFiscalCode:
-              operatorFiscalCode ?? values.organizationFiscalCode
+              operatorFiscalCode ?? values.organizationFiscalCode!
           }
         });
       })}
@@ -261,7 +261,7 @@ const CreateEditActivationForm = () => {
             outline
             color="primary"
             tag="button"
-            onClick={() => history.push(ADMIN_PANEL_ACCESSI)}
+            onClick={() => navigate(ADMIN_PANEL_ACCESSI)}
           >
             Indietro
           </Button>

--- a/src/components/Form/CreateEditDiscountForm.tsx
+++ b/src/components/Form/CreateEditDiscountForm.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useHistory, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "design-react-kit";
 import { remoteData } from "../../api/common";
 import { useTooltip } from "../../context/tooltip";
@@ -22,7 +22,7 @@ import {
 
 export const CreateEditDiscountForm = () => {
   const { discountId } = useParams<{ discountId: string }>();
-  const history = useHistory();
+  const navigate = useNavigate();
   const agreement = useCgnSelector(selectAgreement);
   const { triggerTooltip } = useTooltip();
 
@@ -37,7 +37,7 @@ export const CreateEditDiscountForm = () => {
   const createDiscountMutation =
     remoteData.Index.Discount.createDiscount.useMutation({
       onSuccess() {
-        history.push(DASHBOARD);
+        navigate(DASHBOARD);
       },
       onError: createDiscountMutationOnError(triggerTooltip)
     });
@@ -45,13 +45,13 @@ export const CreateEditDiscountForm = () => {
   const updateDiscountMutation =
     remoteData.Index.Discount.updateDiscount.useMutation({
       onSuccess() {
-        history.push(DASHBOARD);
+        navigate(DASHBOARD);
       },
       onError: updateDiscountMutationOnError(triggerTooltip)
     });
 
   const discountQuery = remoteData.Index.Discount.getDiscountById.useQuery(
-    { agreementId: agreement.id, discountId },
+    { agreementId: agreement.id, discountId: discountId! },
     { enabled: Boolean(discountId) }
   );
   const discount = discountQuery.data;
@@ -110,7 +110,7 @@ export const CreateEditDiscountForm = () => {
             outline={!isDraft}
             tag="button"
             color={isDraft ? "secondary" : "primary"}
-            onClick={() => history.push(DASHBOARD)}
+            onClick={() => navigate(DASHBOARD)}
           >
             {isDraft ? "Annulla" : "Indietro"}
           </Button>

--- a/src/components/Form/EditOperatorDataForm/EditOperatorDataForm.tsx
+++ b/src/components/Form/EditOperatorDataForm/EditOperatorDataForm.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useMemo } from "react";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "design-react-kit";
 import { remoteData } from "../../../api/common";
 import { DASHBOARD } from "../../../navigation/routes";
@@ -54,7 +54,7 @@ function OperatorDataButtons({ isPending, onBack }: OperatorDataButtonsProps) {
 }
 
 export const EditOperatorForm = ({ variant }: Props) => {
-  const history = useHistory();
+  const navigate = useNavigate();
   const agreement = useCgnSelector(selectAgreement);
 
   const profileQuery = remoteData.Index.Profile.getProfile.useQuery({
@@ -69,7 +69,7 @@ export const EditOperatorForm = ({ variant }: Props) => {
   const editProfileMutation =
     remoteData.Index.Profile.updateProfile.useMutation({
       onSuccess() {
-        history.push(DASHBOARD);
+        navigate(DASHBOARD);
       }
     });
 
@@ -127,7 +127,7 @@ export const EditOperatorForm = ({ variant }: Props) => {
                   entityType={entityType}
                 >
                   <OperatorDataButtons
-                    onBack={() => history.push(DASHBOARD)}
+                    onBack={() => navigate(DASHBOARD)}
                     isPending={isPending}
                   />
                 </SalesChannels>
@@ -144,7 +144,7 @@ export const EditOperatorForm = ({ variant }: Props) => {
                 />
                 <ReferentData formLens={form.lens}>
                   <OperatorDataButtons
-                    onBack={() => history.push(DASHBOARD)}
+                    onBack={() => navigate(DASHBOARD)}
                     isPending={isPending}
                   />
                 </ReferentData>

--- a/src/components/OperatorActivations/ActivationsFilter.tsx
+++ b/src/components/OperatorActivations/ActivationsFilter.tsx
@@ -1,5 +1,5 @@
 import { Button } from "design-react-kit";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { ADMIN_PANEL_ACCESSI_CREA } from "../../navigation/routes";
 import { ActivationsFilterFormValues } from "./OperatorActivations";
 
@@ -18,7 +18,7 @@ function ActivationsFilter({
   onReset(): void;
   hasActiveFitlers: boolean;
 }) {
-  const history = useHistory();
+  const navigate = useNavigate();
 
   return (
     <form>
@@ -60,7 +60,7 @@ function ActivationsFilter({
             className="ms-5 btn-sm"
             color="primary"
             tag="button"
-            onClick={() => history.push(ADMIN_PANEL_ACCESSI_CREA)}
+            onClick={() => navigate(ADMIN_PANEL_ACCESSI_CREA)}
           >
             <span>Aggiungi operatore</span>
           </Button>

--- a/src/components/OperatorActivations/OperatorActivationDetail.tsx
+++ b/src/components/OperatorActivations/OperatorActivationDetail.tsx
@@ -1,6 +1,6 @@
 import { format } from "date-fns";
 import { useState } from "react";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "design-react-kit";
 import { OrganizationWithReferents } from "../../api/generated_backoffice";
 import ProfileItem from "../Profile/ProfileItem";
@@ -17,7 +17,7 @@ type Props = {
 };
 
 const OperatorActivationDetail = ({ operator, getActivations }: Props) => {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { triggerTooltip } = useTooltip();
 
@@ -95,9 +95,7 @@ const OperatorActivationDetail = ({ operator, getActivations }: Props) => {
           outline
           tag="button"
           onClick={() =>
-            history.push(
-              getEditOperatorRoute(operator.keyOrganizationFiscalCode)
-            )
+            navigate(getEditOperatorRoute(operator.keyOrganizationFiscalCode))
           }
         >
           <span>Modifica</span>

--- a/src/navigation/RouterConfig.tsx
+++ b/src/navigation/RouterConfig.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Redirect, Route, Switch } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router-dom";
 import { AgreementState } from "../api/generated";
 import { useAuthentication } from "../authentication/AuthenticationContext";
 import CenteredLoading from "../components/CenteredLoading/CenteredLoading";
@@ -53,52 +53,37 @@ const RouterConfig = () => {
 
   if (authentication.currentSession.type === "none") {
     return (
-      <Switch>
-        <Route exact path={LOGIN} component={Login} />
-        <Route exact path={LOGIN_REDIRECT} component={LoginRedirect} />
-        <Route path="*">
-          <Redirect to={LOGIN} />
-        </Route>
-      </Switch>
+      <Routes>
+        <Route path={LOGIN} element={<Login />} />
+        <Route path={LOGIN_REDIRECT} element={<LoginRedirect />} />
+        <Route path="*" element={<Navigate to={LOGIN} replace />} />
+      </Routes>
     );
   }
   if (authentication.currentSession.type === "admin") {
     return (
-      <Switch>
-        <Route exact path={LOGIN} component={Login} />
-        <Route exact path={LOGIN_REDIRECT} component={LoginRedirect} />
+      <Routes>
+        <Route path={LOGIN} element={<Login />} />
+        <Route path={LOGIN_REDIRECT} element={<LoginRedirect />} />
+        <Route path={ADMIN_PANEL_RICHIESTE} element={<AdminPanel />} />
+        <Route path={ADMIN_PANEL_CONVENZIONATI} element={<AdminPanel />} />
+        <Route path={ADMIN_PANEL_ACCESSI} element={<AdminPanel />} />
+        <Route path={ADMIN_PANEL_ACCESSI_EDIT} element={<EditActivation />} />
+        <Route path={ADMIN_PANEL_ACCESSI_CREA} element={<CreateActivation />} />
         <Route
-          exact
-          path={[
-            ADMIN_PANEL_RICHIESTE,
-            ADMIN_PANEL_CONVENZIONATI,
-            ADMIN_PANEL_ACCESSI
-          ]}
-          component={AdminPanel}
+          path="*"
+          element={<Navigate to={ADMIN_PANEL_RICHIESTE} replace />}
         />
-        <Route
-          exact
-          path={ADMIN_PANEL_ACCESSI_EDIT}
-          component={EditActivation}
-        />
-        <Route
-          exact
-          path={ADMIN_PANEL_ACCESSI_CREA}
-          component={CreateActivation}
-        />
-        <Route path="*">
-          <Redirect to={ADMIN_PANEL_RICHIESTE} />
-        </Route>
-      </Switch>
+      </Routes>
     );
   }
   if (!authentication.currentSession.merchantFiscalCode) {
     return (
-      <Switch>
-        <Route exact path={LOGIN} component={Login} />
-        <Route exact path={LOGIN_REDIRECT} component={LoginRedirect} />
-        <Route path="*" component={SelectCompany} />
-      </Switch>
+      <Routes>
+        <Route path={LOGIN} element={<Login />} />
+        <Route path={LOGIN_REDIRECT} element={<LoginRedirect />} />
+        <Route path="*" element={<SelectCompany />} />
+      </Routes>
     );
   }
   if (loading) {
@@ -107,44 +92,38 @@ const RouterConfig = () => {
   switch (agreement.state) {
     case AgreementState.DraftAgreement: {
       return (
-        <Switch>
-          <Route exact path={LOGIN} component={Login} />
-          <Route exact path={LOGIN_REDIRECT} component={LoginRedirect} />
-          <Route exact path={CREATE_PROFILE} component={CreateProfile} />
-          <Route path="*">
-            <Redirect to={CREATE_PROFILE} />
-          </Route>
-        </Switch>
+        <Routes>
+          <Route path={LOGIN} element={<Login />} />
+          <Route path={LOGIN_REDIRECT} element={<LoginRedirect />} />
+          <Route path={CREATE_PROFILE} element={<CreateProfile />} />
+          <Route path="*" element={<Navigate to={CREATE_PROFILE} replace />} />
+        </Routes>
       );
     }
     case AgreementState.RejectedAgreement: {
       return (
-        <Switch>
-          <Route exact path={LOGIN} component={Login} />
-          <Route exact path={LOGIN_REDIRECT} component={LoginRedirect} />
-          <Route exact path={CREATE_PROFILE} component={CreateProfile} />
-          <Route exact path={REJECT_PROFILE} component={RejectedProfile} />
-          <Route path="*">
-            <Redirect to={REJECT_PROFILE} />
-          </Route>
-        </Switch>
+        <Routes>
+          <Route path={LOGIN} element={<Login />} />
+          <Route path={LOGIN_REDIRECT} element={<LoginRedirect />} />
+          <Route path={CREATE_PROFILE} element={<CreateProfile />} />
+          <Route path={REJECT_PROFILE} element={<RejectedProfile />} />
+          <Route path="*" element={<Navigate to={REJECT_PROFILE} replace />} />
+        </Routes>
       );
     }
     default: {
       return (
-        <Switch>
-          <Route exact path={LOGIN} component={Login} />
-          <Route exact path={LOGIN_REDIRECT} component={LoginRedirect} />
-          <Route exact path={DASHBOARD} component={Dashboard} />
-          <Route exact path={EDIT_PROFILE} component={EditProfile} />
-          <Route exact path={CREATE_DISCOUNT} component={CreateDiscount} />
-          <Route exact path={EDIT_DISCOUNT} component={EditDiscount} />
-          <Route exact path={EDIT_OPERATOR_DATA} component={EditOperatorData} />
-          <Route exact path={REJECT_PROFILE} component={RejectedProfile} />
-          <Route path="*">
-            <Redirect to={DASHBOARD} />
-          </Route>
-        </Switch>
+        <Routes>
+          <Route path={LOGIN} element={<Login />} />
+          <Route path={LOGIN_REDIRECT} element={<LoginRedirect />} />
+          <Route path={DASHBOARD} element={<Dashboard />} />
+          <Route path={EDIT_PROFILE} element={<EditProfile />} />
+          <Route path={CREATE_DISCOUNT} element={<CreateDiscount />} />
+          <Route path={EDIT_DISCOUNT} element={<EditDiscount />} />
+          <Route path={EDIT_OPERATOR_DATA} element={<EditOperatorData />} />
+          <Route path={REJECT_PROFILE} element={<RejectedProfile />} />
+          <Route path="*" element={<Navigate to={DASHBOARD} replace />} />
+        </Routes>
       );
     }
   }

--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useHistory } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import Layout from "../components/Layout/Layout";
 import { ContainerFluid } from "../components/Container/Container";
 import IntroductionAdmin from "../components/Introduction/IntroductionAdmin";
@@ -14,13 +14,13 @@ import { useAuthentication } from "../authentication/AuthenticationContext";
 
 const AdminPanel = () => {
   const location = useLocation();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const authentication = useAuthentication();
   const user = authentication.currentAdminSession;
 
   const handleClick = (newTab: string) => {
-    history.push(newTab);
+    navigate(newTab);
   };
 
   const selectedTab = () => {

--- a/src/pages/RejectedProfile.tsx
+++ b/src/pages/RejectedProfile.tsx
@@ -1,4 +1,4 @@
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "design-react-kit";
 import Layout from "../components/Layout/Layout";
 import Container from "../components/Container/Container";
@@ -11,7 +11,7 @@ import { useCgnSelector } from "../store/hooks";
 
 const RejectedProfile = () => {
   const agreement = useCgnSelector(selectAgreement);
-  const history = useHistory();
+  const navigate = useNavigate();
   const authentication = useAuthentication();
   return (
     <Layout>
@@ -55,7 +55,7 @@ const RejectedProfile = () => {
               <Button
                 color="primary"
                 className="ms-4"
-                onClick={() => history.push(CREATE_PROFILE)}
+                onClick={() => navigate(CREATE_PROFILE)}
                 style={{ width: "175px" }}
               >
                 Modifica dati

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,7 +157,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.21.0", "@babel/runtime@^7.24.7", "@babel/runtime@^7.26.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.21.0", "@babel/runtime@^7.24.7", "@babel/runtime@^7.26.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.7":
   version "7.27.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
   integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
@@ -1404,11 +1404,6 @@
   resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.7.tgz#8dbb2f24bdc7486c54aa854eb414940bbd056f7d"
   integrity sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==
 
-"@types/history@^4.7.11":
-  version "4.7.11"
-  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
-  integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
-
 "@types/json-schema@^7.0.15":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -1440,23 +1435,6 @@
   version "19.1.6"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.1.6.tgz#4af629da0e9f9c0f506fc4d1caa610399c595d64"
   integrity sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==
-
-"@types/react-router-dom@^5.1.7":
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
-  integrity sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==
-  dependencies:
-    "@types/history" "^4.7.11"
-    "@types/react" "*"
-    "@types/react-router" "*"
-
-"@types/react-router@*":
-  version "5.1.20"
-  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.20.tgz#88eccaa122a82405ef3efbcaaa5dcdd9f021387c"
-  integrity sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==
-  dependencies:
-    "@types/history" "^4.7.11"
-    "@types/react" "*"
 
 "@types/react-table@^7.0.29":
   version "7.7.20"
@@ -2331,6 +2309,11 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookie@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
+  integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
 
 cosmiconfig@^8.1.3:
   version "8.3.6"
@@ -3522,25 +3505,6 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-history@^4.9.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
-  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    loose-envify "^1.2.0"
-    resolve-pathname "^3.0.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-    value-equal "^1.0.1"
-
-hoist-non-react-statics@^3.1.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
-  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  dependencies:
-    react-is "^16.7.0"
-
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
@@ -3925,11 +3889,6 @@ is-wsl@^2.1.1:
   dependencies:
     is-docker "^2.0.0"
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
-
 isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
@@ -4224,7 +4183,7 @@ log-update@^6.1.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
-loose-envify@^1.0.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -4774,13 +4733,6 @@ path-to-regexp@8.2.0:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.2.0.tgz#73990cc29e57a3ff2a0d914095156df5db79e8b4"
   integrity sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==
 
-path-to-regexp@^1.7.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
-  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
-  dependencies:
-    isarray "0.0.1"
-
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -4985,7 +4937,7 @@ react-hook-form@^7.60.0:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.60.0.tgz#cc4bfa2952d602fc8f1dcf2d4929fcb6d9cdc782"
   integrity sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==
 
-react-is@^16.13.1, react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0:
+react-is@^16.13.1, react-is@^16.3.2:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -5016,33 +4968,20 @@ react-refresh@^0.17.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.17.0.tgz#b7e579c3657f23d04eccbe4ad2e58a8ed51e7e53"
   integrity sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==
 
-react-router-dom@^5.2.0:
-  version "5.3.4"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.4.tgz#2ed62ffd88cae6db134445f4a0c0ae8b91d2e5e6"
-  integrity sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==
+react-router-dom@^7.2.0:
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.15.0.tgz#a4b95c4402d896c2ad437014aff9076b94673063"
+  integrity sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==
   dependencies:
-    "@babel/runtime" "^7.12.13"
-    history "^4.9.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.2"
-    react-router "5.3.4"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
+    react-router "7.15.0"
 
-react-router@5.3.4:
-  version "5.3.4"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.3.4.tgz#8ca252d70fcc37841e31473c7a151cf777887bb5"
-  integrity sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==
+react-router@7.15.0:
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.15.0.tgz#cb438ff254ab5a1e356ef5a23d7821d8f6fbe652"
+  integrity sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==
   dependencies:
-    "@babel/runtime" "^7.12.13"
-    history "^4.9.0"
-    hoist-non-react-statics "^3.1.0"
-    loose-envify "^1.3.1"
-    path-to-regexp "^1.7.0"
-    prop-types "^15.6.2"
-    react-is "^16.6.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
+    cookie "^1.0.1"
+    set-cookie-parser "^2.6.0"
 
 react-toastify@^7.0.4:
   version "7.0.4"
@@ -5183,11 +5122,6 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
-
-resolve-pathname@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
-  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve@^1.10.0, resolve@^1.22.4:
   version "1.22.10"
@@ -5403,6 +5337,11 @@ semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+set-cookie-parser@^2.6.0:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz#ccd08673a9ae5d2e44ea2a2de25089e67c7edf68"
+  integrity sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -5911,16 +5850,6 @@ through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-tiny-invariant@^1.0.2:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
-  integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
-
-tiny-warning@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
-  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
-
 tinybench@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
@@ -6186,11 +6115,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
-
-value-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
-  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 "video.js@^7 || ^8", video.js@^8.21.0:
   version "8.23.3"


### PR DESCRIPTION
## Short description
This pull request updates the codebase to use the new `useNavigate` hook from `react-router-dom` instead of the deprecated `useHistory` hook, and upgrades `react-router-dom` to version 7.2.0. It also updates ESLint configuration to allow safe floating promises for known navigation calls, and removes the now-unnecessary `@types/react-router-dom` dependency.

## List of changes proposed in this pull request
- Upgraded `react-router-dom` from version `5.2.0` to `7.2.0`
- Replaced all usage of `useHistory` with `useNavigate` from `react-router-dom` throughout the codebase
- Removed the `@types/react-router-dom` dependency from `package.json` as it's no longer needed with the upgraded version
- Updated the ESLint rule for `@typescript-eslint/no-floating-promises` to allow floating promises for known safe navigation calls (e.g., `NavigateFunction` from `react-router`).

## How to test
- Ensure that application start with no issue;
- Ensure that build is not generating issue;
- Ensure that navigation between pages is not making the website going blank.