### PR TITLE
fix: [IEG-000] CGN extension session login

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ to test minified bundled version of the dashboard use `yarn build:uat-local && y
 
 ## Login in localhost 
 As soon as the dashboard is up and running, you will see a landing page where you should login. Choose what kind of login do you want (login as Operator or login as Admin).
-After that you logged in successfully, you will be redirected to UAT environment dashboard. In this case, you need to retrieve the token generated in UAT and put it in the localhost environment. You can do this in three ways:
+After that you logged in successfully, you will be redirected to UAT environment dashboard. In this case, you need to retrieve the token generated in UAT and put it in the localhost environment. You can do this in two ways:
 
 ### Option 1: Using the Browser Console
 
@@ -94,12 +94,35 @@ dialog.showModal();
 
 ### Option 2: Using the Browser Extension
 
-To simplify the process, you can use the provided browser extension. This extension automates the retrieval of the token from the UAT environment and applies it to the localhost environment.
+To simplify the process, you can use the provided browser extension. The extension reads the `oneidentity` session from the authenticated page and applies it to `http://localhost:3000`.
+
+The extension supports:
+- Direct transfer of the current session to localhost
+- Multiple saved named sessions (for example `admin` and `user`)
+- Reusing a selected saved session on localhost
 
 #### Steps to Use the Extension
-1. Install the extension in your browser. You can find the extension in the [extensions/login](extensions/login) folder.
-2. Navigate to the UAT environment dashboard and log in.
-3. Open the extension and click the "Retrieve CGN token" button.
-4. The extension will automatically copy the token and apply it to the localhost environment.
+1. Install the extension in your browser from the [extensions/login](extensions/login) folder.
+2. Navigate to the authenticated environment (for example UAT) and log in.
+3. Open the extension popup.
+4. Choose one of the following flows:
+   - Quick transfer: click `Use current on localhost`
+   - Save session for reuse:
+     - Type a session name (for example `admin` or `user`)
+     - Click `Save current session`
+     - Select that session from `Saved sessions`
+     - Click `Use selected on localhost`
+5. A localhost tab opens and the extension injects `localStorage.setItem("oneidentity", token)` and reloads the page.
+
+#### Manage multiple sessions
+- Save one session as `admin`
+- Log in with another account and save as `user`
+- Switch between them from the popup `Saved sessions` selector
+- Use `Delete selected` to remove old sessions
+
+#### Troubleshooting
+- If the popup or background script changed, reload the unpacked extension from `chrome://extensions`
+- Ensure localhost is running on `http://localhost:3000`
+- If transfer fails, open extension logs from `chrome://extensions` and check popup/background console errors
 
 This eliminates the need to manually execute the JavaScript snippet in the browser console.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   - [Login in localhost](#login-in-localhost)
     - [Option 1: Using the Browser Console](#option-1-using-the-browser-console)
     - [Option 2: Using the Browser Extension](#option-2-using-the-browser-extension)
-      - [Steps to Use the Extension](#steps-to-use-the-extension)
+      - [Extension Documentation](#extension-documentation)
  
 
 # Getting started
@@ -94,35 +94,12 @@ dialog.showModal();
 
 ### Option 2: Using the Browser Extension
 
-To simplify the process, you can use the provided browser extension. The extension reads the `oneidentity` session from the authenticated page and applies it to `http://localhost:3000`.
+To simplify the process, you can use the provided browser extension.
 
-The extension supports:
-- Direct transfer of the current session to localhost
-- Multiple saved named sessions (for example `admin` and `user`)
-- Reusing a selected saved session on localhost
+#### Extension Documentation
 
-#### Steps to Use the Extension
-1. Install the extension in your browser from the [extensions/login](extensions/login) folder.
-2. Navigate to the authenticated environment (for example UAT) and log in.
-3. Open the extension popup.
-4. Choose one of the following flows:
-   - Quick transfer: click `Use current on localhost`
-   - Save session for reuse:
-     - Type a session name (for example `admin` or `user`)
-     - Click `Save current session`
-     - Select that session from `Saved sessions`
-     - Click `Use selected on localhost`
-5. A localhost tab opens and the extension injects `localStorage.setItem("oneidentity", token)` and reloads the page.
+Extension setup, multi-session management (admin/user), and troubleshooting are documented in:
 
-#### Manage multiple sessions
-- Save one session as `admin`
-- Log in with another account and save as `user`
-- Switch between them from the popup `Saved sessions` selector
-- Use `Delete selected` to remove old sessions
-
-#### Troubleshooting
-- If the popup or background script changed, reload the unpacked extension from `chrome://extensions`
-- Ensure localhost is running on `http://localhost:3000`
-- If transfer fails, open extension logs from `chrome://extensions` and check popup/background console errors
+- [extensions/login/README.md](extensions/login/README.md)
 
 This eliminates the need to manually execute the JavaScript snippet in the browser console.

--- a/extensions/login/README.md
+++ b/extensions/login/README.md
@@ -1,0 +1,59 @@
+# CGN Session Extension
+
+This extension helps move an authenticated `oneidentity` session from the source environment (for example UAT) to `http://localhost:3000`.
+
+## What it does
+
+- Reads `localStorage.oneidentity` from the active authenticated tab
+- Opens `http://localhost:3000`
+- Sets `localStorage.oneidentity` on localhost and reloads the page
+- Supports multiple named saved sessions (for example `admin`, `user`)
+
+## Install the extension
+
+1. Open `chrome://extensions`
+2. Enable **Developer mode**
+3. Click **Load unpacked**
+4. Select this folder: `extensions/login`
+
+If you update extension files, click **Reload** on the extension card.
+
+## Usage
+
+### Quick transfer (current account)
+
+1. Open the authenticated source page (UAT or other environment)
+2. Open extension popup
+3. Click **Use current on localhost**
+4. A localhost tab opens and session is applied automatically
+
+### Save and reuse multiple sessions
+
+1. Log in with first account (example: admin)
+2. Open popup, set session name to `admin`, click **Save current session**
+3. Log in with second account (example: user)
+4. Open popup, set session name to `user`, click **Save current session**
+5. To switch account on localhost:
+   - Select a name in **Saved sessions**
+   - Click **Use selected on localhost**
+
+### Delete a saved session
+
+1. Select the session name
+2. Click **Delete selected**
+
+## Troubleshooting
+
+- Ensure app is running on `http://localhost:3000`
+- Reload extension after code changes from `chrome://extensions`
+- If transfer fails, inspect errors in:
+  - popup console
+  - background service worker console
+
+## Permissions used
+
+- `activeTab`: read session from current tab
+- `scripting`: execute session read/injection scripts
+- `tabs`: open localhost tab and listen for tab updates
+- `storage`: save named sessions and pending transfers
+- `clipboardWrite`: fallback copy flow support

--- a/extensions/login/background.js
+++ b/extensions/login/background.js
@@ -1,21 +1,116 @@
-chrome.runtime.onMessage.addListener(message => {
-  if (message.action === "setCookie" && message.cookie) {
-    chrome.cookies.set(
-      {
-        url: "http://localhost/",
-        name: message.cookie.name,
-        value: message.cookie.value,
-        domain: message.cookie.domain,
-        path: message.cookie.path,
-        secure: message.cookie.secure
-      },
-      cookie => {
-        if (chrome.runtime.lastError) {
-          console.error("Failed to set cookie:", chrome.runtime.lastError);
-        } else {
-          console.log("Cookie set successfully:", cookie);
-        }
-      }
-    );
+const PENDING_TRANSFERS_KEY = "pendingOneIdentityTransfers";
+const extensionApi = globalThis.chrome ?? globalThis.browser;
+let pendingTransfersFallback = {};
+
+function getPendingTransfers(callback) {
+  if (!extensionApi?.storage?.local) {
+    callback(pendingTransfersFallback);
+    return;
   }
+
+  extensionApi.storage.local.get(PENDING_TRANSFERS_KEY, store => {
+    const pending = store?.[PENDING_TRANSFERS_KEY] ?? {};
+    callback(pending);
+  });
+}
+
+function setPendingTransfers(pending, callback) {
+  if (!extensionApi?.storage?.local) {
+    pendingTransfersFallback = pending;
+    callback();
+    return;
+  }
+
+  extensionApi.storage.local.set({ [PENDING_TRANSFERS_KEY]: pending }, callback);
+}
+
+function removePendingTransfer(tabId) {
+  getPendingTransfers(pending => {
+    delete pending[String(tabId)];
+    setPendingTransfers(pending, () => {
+      if (extensionApi.runtime.lastError) {
+        console.error(
+          "Failed to clear pending transfer:",
+          extensionApi.runtime.lastError.message
+        );
+      }
+    });
+  });
+}
+
+function injectOneIdentityOnTab(tabId, token) {
+  extensionApi.scripting.executeScript(
+    {
+      target: { tabId },
+      func: currentToken => {
+        localStorage.setItem("oneidentity", currentToken);
+        location.reload();
+      },
+      args: [token]
+    },
+    () => {
+      if (extensionApi.runtime.lastError) {
+        console.error(
+          "Failed to inject oneidentity on localhost:",
+          extensionApi.runtime.lastError.message
+        );
+        return;
+      }
+
+      removePendingTransfer(tabId);
+    }
+  );
+}
+
+extensionApi.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status !== "complete") {
+    return;
+  }
+
+  if (!tab?.url?.startsWith("http://localhost:3000")) {
+    return;
+  }
+
+  getPendingTransfers(pending => {
+    const token = pending[String(tabId)];
+    if (!token) {
+      return;
+    }
+
+    injectOneIdentityOnTab(tabId, token);
+  });
+});
+
+extensionApi.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (
+    message.action !== "setOneIdentityOnLocalhost" ||
+    typeof message.token !== "string"
+  ) {
+    return;
+  }
+
+  extensionApi.tabs.create({ url: "http://localhost:3000" }, tab => {
+    if (extensionApi.runtime.lastError || !tab?.id) {
+      sendResponse({
+        ok: false,
+        error:
+          extensionApi.runtime.lastError?.message ?? "Failed to open localhost tab."
+      });
+      return;
+    }
+
+    getPendingTransfers(pending => {
+      pending[String(tab.id)] = message.token;
+      setPendingTransfers(pending, () => {
+        if (extensionApi.runtime.lastError) {
+          sendResponse({ ok: false, error: extensionApi.runtime.lastError.message });
+          return;
+        }
+
+        sendResponse({ ok: true });
+      });
+    });
+  });
+
+  return true;
 });

--- a/extensions/login/index.css
+++ b/extensions/login/index.css
@@ -1,37 +1,85 @@
 body {
-    width: 300px;
-    height: 100px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    width: 340px;
     margin: 0;
-    background-color: #e8e8e8;
+    background-color: #f4f6f8;
+    color: #1f2a37;
+    font-family: "Segoe UI", sans-serif;
+}
+
+.panel {
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.title {
+    margin: 0 0 4px;
+    font-size: 15px;
+}
+
+.label {
+    font-size: 12px;
+    font-weight: 600;
+    color: #4a5568;
+}
+
+input,
+select {
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid #c6ccd5;
+    border-radius: 8px;
+    padding: 8px;
+    font-size: 13px;
+    background: #fff;
+}
+
+.actions {
+    display: flex;
+    gap: 8px;
 }
 
 button {
-    max-width: 320px;
+    flex: 1;
     display: flex;
-    padding: 0.5rem 1.4rem;
-    font-size: 0.875rem;
-    line-height: 1.25rem;
+    justify-content: center;
+    padding: 0.55rem 0.7rem;
+    font-size: 0.78rem;
+    line-height: 1.1rem;
     font-weight: 700;
     text-align: center;
     text-transform: uppercase;
-    vertical-align: middle;
     align-items: center;
     border-radius: 0.5rem;
-    border: 1px solid rgba(0, 0, 0, 0.25);
-    gap: 0.75rem;
-    color: rgb(65, 63, 63);
+    border: 1px solid #b7bfc9;
+    gap: 0.5rem;
+    color: #2b3748;
     background-color: #fff;
     cursor: pointer;
-    transition: all .6s ease;
+    transition: transform 0.2s ease, background-color 0.2s ease;
 }
 
 .button img {
-    height: 24px;
+    height: 18px;
 }
 
 button:hover {
     transform: scale(1.02);
+}
+
+.secondary {
+    background-color: #edf2f7;
+}
+
+.danger {
+    background-color: #fff2f2;
+    border-color: #e2b8b8;
+}
+
+.status {
+    min-height: 16px;
+    margin: 4px 0 0;
+    font-size: 12px;
+    color: #2d4d7a;
 }

--- a/extensions/login/manifest.json
+++ b/extensions/login/manifest.json
@@ -9,10 +9,11 @@
     "128": "icon.png"
   },
   "permissions": [
-    "cookies",
     "clipboardWrite",
     "scripting",
-    "activeTab"
+    "activeTab",
+    "tabs",
+    "storage"
   ],
   "host_permissions": [
     "http://localhost/*",

--- a/extensions/login/popup.html
+++ b/extensions/login/popup.html
@@ -7,10 +7,32 @@
 </head>
 
 <body>
-  <button class="button" id="button">
-    <img src="icon.png" alt="icon" width="20" height="20">
-    Retrieve CGN token
-  </button>
+  <main class="panel">
+    <h1 class="title">CGN Sessions</h1>
+
+    <label class="label" for="sessionName">Session name</label>
+    <input id="sessionName" type="text" placeholder="admin or user" autocomplete="off">
+
+    <div class="actions">
+      <button class="button" id="saveCurrentButton" type="button">
+        <img src="icon.png" alt="icon" width="20" height="20">
+        Save current session
+      </button>
+      <button class="button secondary" id="sendCurrentButton" type="button">
+        Use current on localhost
+      </button>
+    </div>
+
+    <label class="label" for="sessionSelect">Saved sessions</label>
+    <select id="sessionSelect"></select>
+
+    <div class="actions">
+      <button class="button" id="sendSelectedButton" type="button">Use selected on localhost</button>
+      <button class="button danger" id="deleteSelectedButton" type="button">Delete selected</button>
+    </div>
+
+    <p id="status" class="status" aria-live="polite"></p>
+  </main>
   <script src="popup.js"></script>
 </body>
 

--- a/extensions/login/popup.js
+++ b/extensions/login/popup.js
@@ -1,34 +1,249 @@
-document.getElementById("button").addEventListener("click", async () => {
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+const SAVED_SESSIONS_KEY = "savedOneIdentitySessions";
+const LOCAL_FALLBACK_PREFIX = "cgnExtension:";
+const extensionApi = globalThis.chrome ?? globalThis.browser;
 
-  if (tab.id) {
-    chrome.scripting.executeScript({
-      target: { tabId: tab.id },
-      func: async () => {
-        try {
-          const token = await window.cookieStore.get("pagopa_token");
-          if (token) {
-            // Send token data to background script to set the cookie
-            chrome.runtime.sendMessage({
-              action: "setCookie",
-              cookie: {
-                name: token.name,
-                value: token.value,
-                domain: "localhost",
-                path: "/",
-                secure: false
-              }
-            });
+function readLocalFallback(key) {
+  try {
+    const rawValue = globalThis.localStorage.getItem(`${LOCAL_FALLBACK_PREFIX}${key}`);
+    if (!rawValue) {
+      return undefined;
+    }
 
-            // Redirect to localhost
-            window.location.replace("http://localhost:3000");
-          } else {
-            console.error("Token not found.");
-          }
-        } catch (error) {
-          console.error("Error retrieving token:", error);
-        }
-      }
-    });
+    return JSON.parse(rawValue);
+  } catch (error) {
+    console.warn("Failed to read popup local fallback storage.", error);
+    return undefined;
   }
-});
+}
+
+function writeLocalFallback(key, value) {
+  try {
+    globalThis.localStorage.setItem(`${LOCAL_FALLBACK_PREFIX}${key}`, JSON.stringify(value));
+  } catch (error) {
+    console.warn("Failed to write popup local fallback storage.", error);
+  }
+}
+
+const sessionNameInput = document.getElementById("sessionName");
+const sessionSelect = document.getElementById("sessionSelect");
+const saveCurrentButton = document.getElementById("saveCurrentButton");
+const sendCurrentButton = document.getElementById("sendCurrentButton");
+const sendSelectedButton = document.getElementById("sendSelectedButton");
+const deleteSelectedButton = document.getElementById("deleteSelectedButton");
+const statusLabel = document.getElementById("status");
+
+function setStatus(message) {
+  statusLabel.textContent = message;
+}
+
+function getSavedSessions(callback) {
+  if (!extensionApi?.storage?.local) {
+    callback(readLocalFallback(SAVED_SESSIONS_KEY) ?? {});
+    return;
+  }
+
+  extensionApi.storage.local.get(SAVED_SESSIONS_KEY, store => {
+    const sessions = store?.[SAVED_SESSIONS_KEY] ?? {};
+    callback(sessions);
+  });
+}
+
+function setSavedSessions(sessions, callback) {
+  if (!extensionApi?.storage?.local) {
+    writeLocalFallback(SAVED_SESSIONS_KEY, sessions);
+    callback();
+    return;
+  }
+
+  extensionApi.storage.local.set({ [SAVED_SESSIONS_KEY]: sessions }, callback);
+}
+
+function getCurrentTab(callback) {
+  extensionApi.tabs.query({ active: true, currentWindow: true }, tabs => {
+    callback(tabs[0]);
+  });
+}
+
+function readOneIdentityFromTab(tabId, callback) {
+  extensionApi.scripting.executeScript(
+    {
+      target: { tabId },
+      func: () => {
+        const token = localStorage.getItem("oneidentity");
+        if (!token) {
+          return { ok: false, error: "oneidentity not found in localStorage." };
+        }
+
+        return { ok: true, token };
+      }
+    },
+    callback
+  );
+}
+
+function withCurrentTabToken(callback) {
+  getCurrentTab(tab => {
+    if (!tab?.id) {
+      setStatus("No active tab found.");
+      return;
+    }
+
+    readOneIdentityFromTab(tab.id, results => {
+      if (extensionApi.runtime.lastError || !results?.[0]?.result) {
+        setStatus("Unable to read oneidentity from active tab.");
+        return;
+      }
+
+      const result = results[0].result;
+      if (!result.ok) {
+        setStatus(result.error);
+        return;
+      }
+
+      callback(result.token);
+    });
+  });
+}
+
+function migrateTokenToLocalhost(token) {
+  extensionApi.runtime.sendMessage(
+    {
+      action: "setOneIdentityOnLocalhost",
+      token
+    },
+    response => {
+      if (extensionApi.runtime.lastError || !response?.ok) {
+        setStatus("Automatic transfer failed.");
+        return;
+      }
+
+      setStatus("Session sent to localhost.");
+    }
+  );
+}
+
+function refreshSessionSelect(preferredName) {
+  getSavedSessions(sessions => {
+    const names = Object.keys(sessions).sort((a, b) => a.localeCompare(b));
+
+    sessionSelect.innerHTML = "";
+
+    if (names.length === 0) {
+      const emptyOption = document.createElement("option");
+      emptyOption.value = "";
+      emptyOption.textContent = "No saved sessions";
+      sessionSelect.appendChild(emptyOption);
+      sessionSelect.disabled = true;
+      sendSelectedButton.disabled = true;
+      deleteSelectedButton.disabled = true;
+      return;
+    }
+
+    names.forEach(name => {
+      const option = document.createElement("option");
+      option.value = name;
+      option.textContent = name;
+      sessionSelect.appendChild(option);
+    });
+
+    sessionSelect.disabled = false;
+    sendSelectedButton.disabled = false;
+    deleteSelectedButton.disabled = false;
+
+    if (preferredName && names.includes(preferredName)) {
+      sessionSelect.value = preferredName;
+      return;
+    }
+
+    sessionSelect.selectedIndex = 0;
+  });
+}
+
+function saveCurrentSession() {
+  const sessionName = sessionNameInput.value.trim();
+  if (!sessionName) {
+    setStatus("Write a session name first.");
+    return;
+  }
+
+  withCurrentTabToken(token => {
+    getSavedSessions(sessions => {
+      sessions[sessionName] = token;
+      setSavedSessions(sessions, () => {
+        if (extensionApi.runtime.lastError) {
+          setStatus("Failed to save session.");
+          return;
+        }
+
+        setStatus(`Saved session: ${sessionName}`);
+        refreshSessionSelect(sessionName);
+      });
+    });
+  });
+}
+
+function sendCurrentSession() {
+  withCurrentTabToken(token => {
+    migrateTokenToLocalhost(token);
+  });
+}
+
+function sendSelectedSession() {
+  const selectedSessionName = sessionSelect.value;
+  if (!selectedSessionName) {
+    setStatus("No saved session selected.");
+    return;
+  }
+
+  getSavedSessions(sessions => {
+    const token = sessions[selectedSessionName];
+    if (!token) {
+      setStatus("Selected session is empty.");
+      return;
+    }
+
+    migrateTokenToLocalhost(token);
+  });
+}
+
+function deleteSelectedSession() {
+  const selectedSessionName = sessionSelect.value;
+  if (!selectedSessionName) {
+    setStatus("No saved session selected.");
+    return;
+  }
+
+  getSavedSessions(sessions => {
+    if (!sessions[selectedSessionName]) {
+      setStatus("Selected session does not exist anymore.");
+      refreshSessionSelect();
+      return;
+    }
+
+    delete sessions[selectedSessionName];
+    setSavedSessions(sessions, () => {
+      if (extensionApi.runtime.lastError) {
+        setStatus("Failed to delete session.");
+        return;
+      }
+
+      setStatus(`Deleted session: ${selectedSessionName}`);
+      refreshSessionSelect();
+    });
+  });
+}
+
+saveCurrentButton.addEventListener("click", saveCurrentSession);
+sendCurrentButton.addEventListener("click", sendCurrentSession);
+sendSelectedButton.addEventListener("click", sendSelectedSession);
+deleteSelectedButton.addEventListener("click", deleteSelectedSession);
+
+if (!extensionApi?.tabs || !extensionApi?.scripting || !extensionApi?.runtime) {
+  setStatus("Extension APIs not available in this context.");
+  saveCurrentButton.disabled = true;
+  sendCurrentButton.disabled = true;
+  sendSelectedButton.disabled = true;
+  deleteSelectedButton.disabled = true;
+}
+
+refreshSessionSelect();


### PR DESCRIPTION
## Short description
This pull request significantly improves the Chrome extension for managing CGN session tokens by overhauling the user interface, adding robust session management features, and updating the background logic for transferring sessions to localhost. The extension now allows users to save, select, use, and delete multiple named sessions, and provides a more user-friendly and reliable experience.

## List of changes proposed in this pull request
- Added support for saving multiple named sessions, selecting among them, sending a selected session to localhost, and deleting sessions, all from an improved popup interface
- Replaced the cookie-based transfer mechanism with a new system that injects the session token into `localStorage` on `localhost:3000`, using `chrome.scripting` and robust error handling
- Implemented fallback storage for both session data and pending transfers to handle cases where the extension storage API is unavailable
- Updated extension permissions to remove unnecessary `cookies` permission and add `tabs` and `storage` permissions for new features

## How to test
Play with the extension and verify that all functionality are working