### PR TITLE
fix: [IEG-000] Read store value synchronously at render time

### DIFF
--- a/src/authentication/AuthenticationProvider.tsx
+++ b/src/authentication/AuthenticationProvider.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import { useNavigate } from "react-router-dom";
 import { DASHBOARD, ADMIN_PANEL_RICHIESTE, LOGIN } from "../navigation/routes";
 import { useLoginRedirect, adminLogoutRedirect } from "./authentication";
@@ -12,20 +12,16 @@ import { authenticationStore } from "./authenticationStore";
 
 export function AuthenticationProvider({
   children
-}: {
+}: Readonly<{
   children: React.ReactNode;
-}) {
-  useLoginRedirect();
+}>) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [persistedState, setPersistedState] = useState(authenticationStore.get);
-  useEffect(
-    () =>
-      authenticationStore.subscribe(() => {
-        setPersistedState(authenticationStore.get());
-      }),
-    []
+  const persistedState = useSyncExternalStore(
+    authenticationStore.subscribe,
+    authenticationStore.get
   );
+  useLoginRedirect();
   const { currentSession, userSessionByFiscalCode, adminSessionByName } =
     persistedState;
   const resetQueries = useCallback(() => {
@@ -63,19 +59,19 @@ export function AuthenticationProvider({
       adminSessionByName,
       currentSession,
       currentUserFiscalCode:
-        currentSession && currentSession.type === "user"
+        currentSession?.type === "user"
           ? currentSession.userFiscalCode
           : undefined,
       currentUserSession:
-        currentSession && currentSession.type === "user"
+        currentSession?.type === "user"
           ? userSessionByFiscalCode[currentSession.userFiscalCode]
           : undefined,
       currentMerchantFiscalCode:
-        currentSession && currentSession.type === "user"
+        currentSession?.type === "user"
           ? currentSession.merchantFiscalCode
           : undefined,
       currentMerchant:
-        currentSession && currentSession.type === "user"
+        currentSession?.type === "user"
           ? userSessionByFiscalCode[
               currentSession.userFiscalCode
             ]?.merchants.find(
@@ -85,7 +81,7 @@ export function AuthenticationProvider({
             )
           : undefined,
       currentAdminSession:
-        currentSession && currentSession.type === "admin"
+        currentSession?.type === "admin"
           ? adminSessionByName[currentSession.name]
           : undefined,
       setCurrentSession,

--- a/src/authentication/authentication.ts
+++ b/src/authentication/authentication.ts
@@ -1,7 +1,7 @@
 import { PublicClientApplication } from "@azure/msal-browser";
 import { useQueryClient } from "@tanstack/react-query";
 import { jwtDecode } from "jwt-decode";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { z } from "zod/v4";
 import { API_INDEX_BASE_URL, API_PUBLIC_BASE_URL } from "../api/common";
@@ -177,10 +177,21 @@ export function useLoginRedirect() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
+  // Keep refs current so the one-time effect always calls the latest functions,
+  // without re-running the effect on every navigation.
+  // In React Router v7, `navigate` changes on every location change (it closes
+  // over `locationPathname`), which would cause the effect to re-attach .then()
+  // handlers to the already-resolved singleton promises and re-trigger the
+  // post-login redirects on every subsequent navigation.
+  const navigateRef = useRef(navigate);
+  const queryClientRef = useRef(queryClient);
+  navigateRef.current = navigate;
+  queryClientRef.current = queryClient;
+
   useEffect(() => {
     const resetQueries = () => {
-      queryClient.clear();
-      void queryClient.invalidateQueries();
+      queryClientRef.current.clear();
+      void queryClientRef.current.invalidateQueries();
     };
 
     void userLoginRedirectPromise.then(state => {
@@ -191,9 +202,9 @@ export function useLoginRedirect() {
           merchantFiscalCode: undefined
         });
         resetQueries();
-        navigate(DASHBOARD);
+        navigateRef.current(DASHBOARD);
       } else if (state.type === "error") {
-        navigate(LOGIN);
+        navigateRef.current(LOGIN);
       }
     });
 
@@ -204,8 +215,8 @@ export function useLoginRedirect() {
           name: state.name
         });
         resetQueries();
-        navigate(ADMIN_PANEL_RICHIESTE);
+        navigateRef.current(ADMIN_PANEL_RICHIESTE);
       }
     });
-  }, [navigate, queryClient]);
+  }, []); // intentionally empty: this must run only once on mount
 }


### PR DESCRIPTION
## Short description
This pull request refactors the authentication state management and improves the reliability of the login redirect logic in the authentication flow. The main changes include migrating from `useState`/`useEffect` to `useSyncExternalStore` for subscribing to authentication state, and updating the `useLoginRedirect` hook to avoid issues with stale or changing dependencies in React Router v7 by using refs.

## List of changes proposed in this pull request
- Replaced `useState`/`useEffect` with `useSyncExternalStore` in `AuthenticationProvider` for subscribing to `authenticationStore`, ensuring more reliable and efficient state updates
- Simplified conditional checks for session-related properties by using optional chaining (`currentSession?.type`) instead of logical AND
- Refactored `useLoginRedirect` to use `useRef` for `navigate` and `queryClient`, preventing the effect from re-running unnecessarily due to changes in these dependencies, and ensuring that the latest references are always used.

## How to test
- Navigation issues on UAT portal should be solved 
